### PR TITLE
Use Pillow since pil is not available on Ubuntu 14.04.

### DIFF
--- a/sc2reader/engine/plugins/creeptracker.py
+++ b/sc2reader/engine/plugins/creeptracker.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 from sets import Set
-from Image import open as PIL_open
-from Image import ANTIALIAS 
+from PIL.Image import open as PIL_open
+from PIL.Image import ANTIALIAS 
 from StringIO import StringIO
 from collections import defaultdict
 from itertools import tee


### PR DESCRIPTION
This should be merged first and then ref should be updated in ggpyjobs and then esdb and so forth.
