### PR TITLE
LotV replay length fix

### DIFF
--- a/sc2reader/constants.py
+++ b/sc2reader/constants.py
@@ -60,11 +60,27 @@ MESSAGE_CODES = {
 
 
 GAME_SPEED_FACTOR = {
-    'Slower':   0.6,
-    'Slow':     0.8,
-    'Normal':   1.0,
-    'Fast':     1.2,
-    'Faster':   1.4
+    'WoL': {
+        'Slower':   0.6,
+        'Slow':     0.8,
+        'Normal':   1.0,
+        'Fast':     1.2,
+        'Faster':   1.4
+    },
+    'HotS': {
+        'Slower':   0.6,
+        'Slow':     0.8,
+        'Normal':   1.0,
+        'Fast':     1.2,
+        'Faster':   1.4
+    },
+    'LotV': {
+        'Slower':   0.2,
+        'Slow':     0.4,
+        'Normal':   0.6,
+        'Fast':     0.8,
+        'Faster':   1.0
+    },
 }
 
 GATEWAY_CODES = {

--- a/sc2reader/engine/plugins/creeptracker.py
+++ b/sc2reader/engine/plugins/creeptracker.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 from sets import Set
-from Image import open as PIL_open
-from Image import ANTIALIAS 
+from PIL.Image import open as PIL_open
+from PIL.Image import ANTIALIAS 
 from StringIO import StringIO
 from collections import defaultdict
 from itertools import tee

--- a/test_replays/test_all.py
+++ b/test_replays/test_all.py
@@ -489,6 +489,11 @@ class TestReplays(unittest.TestCase):
         replay = sc2reader.load_replay("test_replays/3.2.0/1.SC2Replay")
         self.assertTrue(replay is not None)
 
+    def test_lotv_time(self):
+      replay = sc2reader.load_replay("test_replays/lotv/lotv1.SC2Replay")
+      self.assertEqual(replay.length.seconds, 1002)
+      self.assertEqual(replay.real_length.seconds, 1002)
+
           
 class TestGameEngine(unittest.TestCase):
     class TestEvent(object):


### PR DESCRIPTION
I read through dsjoerg/ggpyjobs#7 and based on that I'd like to suggest the following changeset to sc2reader to address the game length issue with lotv replays.

The only way I can get it to work in my mind is to interpret `game_fps` as frames-per-normal-game-second. Incidentally, in HotS, that becomes frames-per-real-second, but since game speed multipliers are different in LotV, the original fps interpretation has to be changed - hence the fps change here.

I tested this by uploading HotS and LotV replays to my local ggtrackerstack and game durations show identical to what is shown in-game. I have only tested with Faster speed replays - let me know if I should test with other speeds as well.

Unittests in ggpyjobs and esdb pass locally (everything depending on `vagrant` branches being merged). 2 tests in sc2reader fail (besides the 2 expected), but they also fail on `upstream`, so I don't think they should be addressed here.
