### PR TITLE
Add flake8 to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,18 @@ language: python
 python:
  - 2.6
  - 2.7
- - 3.2
- - 3.3
+ - 3.4
+ - 3.6
  - pypy
 install:
  - python setup.py develop
- - pip install coveralls
+ - pip install coveralls hacking
  - mkdir local_cache
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
  - SC2READER_CACHE_DIR=local_cache coverage run --source=sc2reader test_replays/test_all.py
  - SC2READER_CACHE_DIR=local_cache coverage run --source=sc2reader --append test_s2gs/test_all.py


### PR DESCRIPTION
Python 3.3 goes [EOL](https://docs.python.org/devguide/index.html#branchstatus) in a few weeks so drop it from testing and add Python 3.6.