### PR TITLE
Python 3 scoping rules: human.pids --> human_pids

### DIFF
--- a/sc2reader/scripts/sc2parse.py
+++ b/sc2reader/scripts/sc2parse.py
@@ -45,12 +45,12 @@ def main():
                     if not args.one_each or replay.is_ladder:
                         replay = sc2reader.load_replay(path, debug=True)
 
-                        human.pids = set([human.pid for human in replay.humans])
+                        human_pids = set([human.pid for human in replay.humans])
                         event_pids = set([event.player.pid for event in replay.events if getattr(event, 'player', None)])
                         player_pids = set([player.pid for player in replay.players if player.is_human])
                         ability_pids = set([event.player.pid for event in replay.events if 'CommandEvent' in event.name])
-                        if human.pids != event_pids:
-                            print('Event Pid problem!  pids={pids} but event pids={event_pids}'.format(pids=human.pids, event_pids=event_pids))
+                        if human_pids != event_pids:
+                            print('Event Pid problem!  pids={pids} but event pids={event_pids}'.format(pids=human_pids, event_pids=event_pids))
                             print(' with {path}: {build} - {real_type} on {map_name} - Played {start_time}'.format(path=path, **replay.__dict__))
                         elif player_pids != ability_pids:
                             print('Ability Pid problem!  pids={pids} but event pids={event_pids}'.format(pids=player_pids, event_pids=ability_pids))


### PR DESCRIPTION
Python 3 has more restrictive scoping rules that Python 2 so a variable created inside of a list comprehension is not available outside of that list comprehension.

flake8 testing of https://github.com/ggtracker/sc2reader on Python 3.6.3 

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./sc2reader/scripts/sc2parse.py:48:25: F821 undefined name 'human'
                        human.pids = set([human.pid for human in replay.humans])
                        ^
./sc2reader/scripts/sc2parse.py:52:28: F821 undefined name 'human'
                        if human.pids != event_pids:
                           ^
./sc2reader/scripts/sc2parse.py:53:109: F821 undefined name 'human'
                            print('Event Pid problem!  pids={pids} but event pids={event_pids}'.format(pids=human.pids, event_pids=event_pids))
                                                                                                            ^
3     F821 undefined name 'human'
3
```
This PR creates a new __human_pids__ to hold the set of all __replay.humans.pids__ instead of modifying the pid of the last human in that list.