### PR TITLE
Re-enable Circle CI testing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 2.7 3.5
+    - pyenv global 2.7 3.4
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 2.7 3.4.4
+    - pyenv global 2.7 # 3.4.4
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,14 @@
 machine:
   post:
-    - pyenv global 2.7 3.6
+    - pyenv global 2.7 3.5
+
 dependencies:
   pre:
     - pip install --upgrade pip
-    - pip3 install --upgrade pip
+    # - pip3 install --upgrade pip
     - pip install hacking
-    - pip3 install hacking
+    # - pip3 install hacking
+
 general:
   branches:
     ignore:
@@ -17,11 +19,11 @@ general:
       - old_master
 test:
   override:
-    - python2.7 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-    - python2.7 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - python2.7 -m python -m unittest discover test_replays
-    - python2.7 -m python -m unittest discover test_s2gs
-    - python3.6 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-    - python3.6 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - python3.6 -m python -m unittest discover test_replays
-    - python3.6 -m python -m unittest discover test_s2gs
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - python -m unittest discover test_replays
+    - python -m unittest discover test_s2gs
+    #- python3.6 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    #- python3.6 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    #- python3.6 -m python -m unittest discover test_replays
+    #- python3.6 -m python -m unittest discover test_s2gs

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 2.7 3.4
+    - pyenv global 2.7 3.4.4
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 2.7.12 3.6.2
+    - pyenv global 2.7 3.6
 dependencies:
   pre:
     - pip install --upgrade pip


### PR DESCRIPTION
We can run tests in Python 2.7 but can not run in Python 3.