### PR TITLE
Add an __init__() method to CreepTrack object

### DIFF
--- a/sc2reader/engine/plugins/creeptracker.py
+++ b/sc2reader/engine/plugins/creeptracker.py
@@ -26,6 +26,9 @@ class CreepTracker(object):
     This uses the creep_tracker class to calculate the features
     '''
     name = 'CreepTracker'
+    
+    def __init__(self):
+        self.creepTracker = None
 
     def handleInitGame(self, event, replay):
       try:


### PR DESCRIPTION
Reported in #43 and the Circle CI runs on Python 3 but not Python 2.