### PR TITLE
fix map_creep_spread test in python3

### DIFF
--- a/sc2reader/engine/plugins/creeptracker.py
+++ b/sc2reader/engine/plugins/creeptracker.py
@@ -77,11 +77,12 @@ class CreepTracker(object):
           if player.play_race[0] == 'Z':
             self.creepTracker.reduce_cgu_per_minute(player.pid)
             player.creep_spread_by_minute = self.creepTracker.get_creep_spread_area(player.pid)
+            # note that player.max_creep_spread may be a tuple or an int
             if player.creep_spread_by_minute:
                 player.max_creep_spread  = max(player.creep_spread_by_minute.items(),key=lambda x:x[1])
             else:
                 ## Else statement is for players with no creep spread(ie: not Zerg)
-                player.max_creep_spread  =0
+                player.max_creep_spread  = 0
       except Exception as e:
         print("Whoa! {}".format(e))
         pass

--- a/test_replays/test_all.py
+++ b/test_replays/test_all.py
@@ -431,7 +431,7 @@ class TestReplays(unittest.TestCase):
 
         for player_id in replay.player:
             if replay.player[player_id].play_race == "Zerg":
-                assert replay.player[player_id].max_creep_spread >0
+                assert replay.player[player_id].max_creep_spread != 0
                 assert replay.player[player_id].creep_spread_by_minute
 
     def test_lotv_map(self):


### PR DESCRIPTION
See the bug here

https://circleci.com/gh/ggtracker/sc2reader/157

```
ERROR: test_lotv_creepTracker (test_all.TestReplays)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/circleci/project/test_replays/test_all.py", line 434, in test_lotv_creepTracker
    assert replay.player[player_id].max_creep_spread >0
TypeError: '>' not supported between instances of 'tuple' and 'int'
```

The issue is that the value of `max_creep_spread` in this test is `(900, 25.22680412371134)`, and python2 will allow you to compare the tuple and int and call it true, whereas python3 complains.

I looked at the code

https://github.com/ggtracker/sc2reader/blob/d1b6ede567e9a471d0737b2f5a94be9f8a4f1c60/sc2reader/engine/plugins/creeptracker.py#L80-L84

And there's actually an asymmetry of types here. For zerg, `max_creep_spread` is a tuple (like above), whereas for other races, it is the int 0. My belief is that these should match up, so either zerg should get

```
player.max_creep_spread  = max(player.creep_spread_by_minute.values())
```

or terran/protoss should get

```
player.max_creep_spread = (0, 0)
```

I'm not sure which if either is right, though, since I am concerned that ggtracker may depend on specific checks against either of these.

In any case, this hopefully will fix the unit test. If either @dsjoerg or @sklett-src could chime in, that would be helpful. Worst case is that I will just leave a comment int he plugin noting the asymmetry