### PR TITLE
Early detection of events without a player

### DIFF
--- a/sc2reader/engine/engine.py
+++ b/sc2reader/engine/engine.py
@@ -151,7 +151,6 @@ class GameEngine(object):
         # the front of the line for immediate processing.
         while len(event_queue) > 0:
             event = event_queue.popleft()
-            assert event.player, 'Event with no player: {}'.format(event)
 
             if event.name == 'PluginExit':
                 # Remove the plugin and reset the handlers.
@@ -172,6 +171,7 @@ class GameEngine(object):
             # which get processed after the current event finishes. The new_events
             # batch is constructed in reverse order because extendleft reverses
             # the order again with a series of appendlefts.
+            assert event.player, 'Event with no player: {}'.format(event)
             new_events = collections.deque()
             for event_handler in event_handlers:
                 try:

--- a/sc2reader/engine/engine.py
+++ b/sc2reader/engine/engine.py
@@ -171,7 +171,6 @@ class GameEngine(object):
             # which get processed after the current event finishes. The new_events
             # batch is constructed in reverse order because extendleft reverses
             # the order again with a series of appendlefts.
-            assert event.player, 'Event with no player: {}'.format(event)
             new_events = collections.deque()
             for event_handler in event_handlers:
                 try:

--- a/sc2reader/engine/engine.py
+++ b/sc2reader/engine/engine.py
@@ -151,6 +151,7 @@ class GameEngine(object):
         # the front of the line for immediate processing.
         while len(event_queue) > 0:
             event = event_queue.popleft()
+            assert event.player, 'Event with no player: {}'.format(event)
 
             if event.name == 'PluginExit':
                 # Remove the plugin and reset the handlers.

--- a/sc2reader/engine/plugins/context.py
+++ b/sc2reader/engine/plugins/context.py
@@ -54,6 +54,7 @@ class ContextLoader(object):
             self.logger.error("Other unit {0} not found".format(event.other_unit_id))
 
     def handleTargetUnitCommandEvent(self, event, replay):
+        assert event.player, 'Event with no player: {}'.format(event)
         self.last_target_ability_event[event.player.pid] = event
 
         if not replay.datapack:


### PR DESCRIPTION
There are a class of issues like #61 where __event.player is None__ so this PR should print the event in the stacktrace.