### PR TITLE
add support for Tychus co-op replays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 ============
 
+1.2.0 - October 7, 2018
+-----------------------
+* Added support for Tychus
+* Verified that StarCraft 4.6.1 replays work
+
 1.1.0 - June 26, 2018
 ---------------------
 * Added support for protocol 65895 (StarCraft 4.4.0)

--- a/sc2reader/data/attributes.json
+++ b/sc2reader/data/attributes.json
@@ -712,6 +712,7 @@
         "Rayn": "Raynor",
         "Stuk": "Stukov",
         "Swan": "Swann",
+        "Tych": "Tychus",
         "Vora": "Vorazun",
         "Zaga": "Zagara"
       }

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 setuptools.setup(
     license="MIT",
     name="sc2reader",
-    version='1.1.0',
+    version='1.2.0',
     keywords=["starcraft 2", "sc2", "replay", "parser"],
     description="Utility for parsing Starcraft II replay files",
     long_description=open("README.rst").read()+"\n\n"+open("CHANGELOG.rst").read(),


### PR DESCRIPTION
As far as I can tell, 4.6.0 replays still work. I just had to add Tychus as another commander in the list