### PR TITLE
Fix UnitTypeChangeEvent's __str__()

### DIFF
--- a/sc2reader/events/tracker.py
+++ b/sc2reader/events/tracker.py
@@ -482,7 +482,7 @@ class UnitTypeChangeEvent(TrackerEvent):
         self.unit_type_name = data[2].decode("utf8")
 
     def __str__(self):
-        return self._str_prefix() + "{0: >15} - Unit {0} type changed to {1}".format(
+        return self._str_prefix() + "{0: >15} - Unit {1} type changed to {2}".format(
             str(self.unit.owner), self.unit, self.unit_type_name
         )
 


### PR DESCRIPTION
Just a small typo in `__str__()`, took me longer than it should to figure things out because of it :)

I can't see any tests for this sort of thing so didn't add one.