### PR TITLE
Skip updating the owner on an event with no unit

### DIFF
--- a/sc2reader/engine/plugins/context.py
+++ b/sc2reader/engine/plugins/context.py
@@ -250,7 +250,7 @@ class ContextLoader(object):
                 )
             )
 
-        if event.unit_upkeeper:
+        if event.unit_upkeeper and event.unit:
             if event.unit.owner:
                 event.unit.owner.units.remove(event.unit)
             event.unit.owner = event.unit_upkeeper


### PR DESCRIPTION
On [this replay](https://lotv.spawningtool.com/63035/download/), I was getting this error:

```
>>> sc2reader.load_replay('nounit.SC2Replay')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kevin/sc2reader/sc2reader/factories/sc2factory.py", line 88, in load_replay
    return self.load(Replay, source, options, **new_options)
  File "/home/kevin/sc2reader/sc2reader/factories/sc2factory.py", line 166, in load
    return self._load(cls, resource, filename=filename, options=options)
  File "/home/kevin/sc2reader/sc2reader/factories/sc2factory.py", line 175, in _load
    obj = cls(resource, filename=filename, factory=self, **options)
  File "/home/kevin/sc2reader/sc2reader/resources.py", line 346, in __init__
    engine.run(self)
  File "/home/kevin/sc2reader/sc2reader/engine/engine.py", line 179, in run
    for new_event in event_handler(event, replay) or []:
  File "/home/kevin/sc2reader/sc2reader/engine/plugins/context.py", line 254, in handleUnitOwnerChangeEvent
    if event.unit.owner:
AttributeError: 'NoneType' object has no attribute 'owner'
```

Seemed liked a relatively straightforward change to bypass this block if there is no unit