### PR TITLE
setup.py: Add Python 3.8 and 3.9 to supported list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Games/Entertainment",


### PR DESCRIPTION
Our CircleCI has been testing our code on Python 3.9 for some time now.