### PR TITLE
Fixed depot url template. SC2Reader wasn't working with previous due to blizzard update

### DIFF
--- a/sc2reader/utils.py
+++ b/sc2reader/utils.py
@@ -20,7 +20,7 @@ class DepotFile(object):
     """
 
     #: The url template for all DepotFiles
-    url_template = "http://{0}.depot.battle.net:1119/{1}.{2}"
+    url_template = "https://{0}-s2-depot.classic.blizzard.com/{1}.{2}""
 
     def __init__(self, bytes):
         #: The server the file is hosted on

--- a/sc2reader/utils.py
+++ b/sc2reader/utils.py
@@ -20,7 +20,7 @@ class DepotFile(object):
     """
 
     #: The url template for all DepotFiles
-    url_template = "https://{0}-s2-depot.classic.blizzard.com/{1}.{2}""
+    url_template = "https://{0}-s2-depot.classic.blizzard.com/{1}.{2}"
 
     def __init__(self, bytes):
         #: The server the file is hosted on


### PR DESCRIPTION
Blizzard changed the depot url format.
Updated with new format