### PR TITLE
fix url for CN

### DIFF
--- a/sc2reader/resources.py
+++ b/sc2reader/resources.py
@@ -914,8 +914,6 @@ class Replay(Resource):
 
 
 class Map(Resource):
-    url_template = "https://{}-s2-depot.classic.blizzard.com/{}.s2ma"
-
     def __init__(self, map_file, filename=None, region=None, map_hash=None, **options):
         super(Map, self).__init__(map_file, filename, **options)
 
@@ -998,9 +996,7 @@ class Map(Resource):
     def get_url(cls, region, map_hash):
         """Builds a download URL for the map from its components."""
         if region and map_hash:
-            # it seems like sea maps are stored on us depots.
-            region = "us" if region == "sea" else region
-            return cls.url_template.format(region, map_hash)
+            return utils.get_resource_url(region, hash, "s2ma")
         else:
             return None
 
@@ -1020,8 +1016,6 @@ class GameSummary(Resource):
     have a completely different format for the report, which means
     that the data is not necessarily in the places we expect.
     """
-
-    url_template = "https://{}-s2-depot.classic.blizzard.com/{}.s2gs"
 
     #: Game speed
     game_speed = str()
@@ -1450,10 +1444,6 @@ class GameSummary(Resource):
 class MapHeader(Resource):
     """**Experimental**"""
 
-    base_url_template = "https://{}-s2-depot.classic.blizzard.com/{}.{}"
-    url_template = "https://{}-s2-depot.classic.blizzard.com/{}.s2mh"
-    image_url_template = "https://{}-s2-depot.classic.blizzard.com/{}.s2mv"
-
     #: The name of the map
     name = str()
 
@@ -1488,14 +1478,14 @@ class MapHeader(Resource):
         # Parse image hash
         parsed_hash = utils.parse_hash(self.data[0][1])
         self.image_hash = parsed_hash["hash"]
-        self.image_url = self.image_url_template.format(
-            parsed_hash["server"], parsed_hash["hash"]
+        self.image_url = utils.get_resource_url(
+            parsed_hash["server"], parsed_hash["hash"], "s2mv"
         )
 
         # Parse map hash
         parsed_hash = utils.parse_hash(self.data[0][2])
         self.map_hash = parsed_hash["hash"]
-        self.map_url = self.base_url_template.format(
+        self.map_url = utils.get_resource_url(
             parsed_hash["server"], parsed_hash["hash"], parsed_hash["type"]
         )
 
@@ -1503,6 +1493,6 @@ class MapHeader(Resource):
         l18n_struct = self.data[0][4][8]
         for l in l18n_struct:
             parsed_hash = utils.parse_hash(l[1][0])
-            self.localization_urls[l[0]] = self.base_url_template.format(
+            self.localization_urls[l[0]] = utils.get_resource_url(
                 parsed_hash["server"], parsed_hash["hash"], parsed_hash["type"]
             )

--- a/sc2reader/utils.py
+++ b/sc2reader/utils.py
@@ -19,24 +19,9 @@ class DepotFile(object):
     and assembles them into a URL so that the dependency can be fetched.
     """
 
-    #: The url template for all DepotFiles
-    url_template = "{}://{}-s2-depot.{}/{}.{}"
-
     def __init__(self, bytes):
         #: The server the file is hosted on
-        self.server = bytes[4:8].decode("utf-8").strip("\x00 ")
-
-        # Used to make it possible to load maps from CN.
-        # This isn't needed for any other region and so is blank by default.
-        self.scheme = "https"
-        self.domain = "classic.blizzard.com"
-
-        # There is no SEA depot, use US instead
-        if self.server == "SEA":
-            self.server = "US"
-        elif self.server == "CN":
-            self.scheme = "http"
-            self.domain = "battlenet.com.cn"
+        self.server = bytes[4:8].decode("utf-8").strip("\x00 ").lower()
 
         #: The unique content based hash of the file
         self.hash = binascii.b2a_hex(bytes[8:]).decode("utf8")
@@ -47,9 +32,7 @@ class DepotFile(object):
     @property
     def url(self):
         """Returns url of the depot file."""
-        return self.url_template.format(
-            self.scheme, self.server, self.domain, self.hash, self.type
-        )
+        return get_resource_url(self.server, self.hash, self.type)
 
     def __hash__(self):
         return hash(self.url)
@@ -208,6 +191,19 @@ def get_files(
                 yield os.path.join(root, filename)
 
             depth -= 1
+
+
+def get_resource_url(region, hash, type):
+    url_template = "{}://{}-s2-depot.{}/{}.{}"
+    scheme = "https"
+    domain = "classic.blizzard.com"
+
+    if region == "sea":
+        region = "us"
+    elif region == "cn":
+        scheme = "http"
+        domain = "battlenet.com.cn"
+    return url_template.format(scheme, region, domain, hash, type)
 
 
 class Length(timedelta):

--- a/sc2reader/utils.py
+++ b/sc2reader/utils.py
@@ -20,7 +20,7 @@ class DepotFile(object):
     """
 
     #: The url template for all DepotFiles
-    url_template = "https://{}-s2-depot.classic.blizzard.com{}/{}.{}"
+    url_template = "{}://{}-s2-depot.{}/{}.{}"
 
     def __init__(self, bytes):
         #: The server the file is hosted on
@@ -28,13 +28,15 @@ class DepotFile(object):
 
         # Used to make it possible to load maps from CN.
         # This isn't needed for any other region and so is blank by default.
-        self.url_suffix = ""
+        self.scheme = "https"
+        self.domain = "classic.blizzard.com"
 
         # There is no SEA depot, use US instead
         if self.server == "SEA":
             self.server = "US"
         elif self.server == "CN":
-            self.url_suffix = ".cn"
+            self.scheme = "http"
+            self.domain = "battlenet.com.cn"
 
         #: The unique content based hash of the file
         self.hash = binascii.b2a_hex(bytes[8:]).decode("utf8")
@@ -46,7 +48,7 @@ class DepotFile(object):
     def url(self):
         """Returns url of the depot file."""
         return self.url_template.format(
-            self.server, self.url_suffix, self.hash, self.type
+            self.scheme, self.server, self.domain, self.hash, self.type
         )
 
     def __hash__(self):


### PR DESCRIPTION
fix #140 

There are some more url templates in `resources.py` like this. If needed, I'll try to fix them too.