### PR TITLE
Update new Battle.net profile url

### DIFF
--- a/docs/source/tutorials/prettyprinter.rst
+++ b/docs/source/tutorials/prettyprinter.rst
@@ -89,7 +89,7 @@ Many of the replay attributes are nested data structures which are generally all
     >>> replay.teams[0].players[0].color.hex
     'B4141E'
     >>> replay.player.name('Remedy').url
-    'http://us.battle.net/sc2/en/profile/2198663/1/Remedy/'
+    'https://starcraft2.com/en-us/profile/1/1/2198663'
 
 Each of these nested structures can be found either on its own reference page or lumped together with the other minor structures on the Misc Structures page.
 

--- a/sc2reader/objects.py
+++ b/sc2reader/objects.py
@@ -241,6 +241,9 @@ class Player(object):
         #: The Battle.net region the entity is registered to
         self.region = GATEWAY_LOOKUP[detail_data["bnet"]["region"]]
 
+        #: The Battle.net region id the entity is registered to
+        self.region_id = detail_data["bnet"]["region"]
+
         #: The Battle.net subregion the entity is registered to
         self.subregion = detail_data["bnet"]["subregion"]
 
@@ -258,7 +261,7 @@ class User(object):
 
     #: The Battle.net profile url template
     URL_TEMPLATE = (
-        "http://{region}.battle.net/sc2/en/profile/{toon_id}/{subregion}/{name}/"
+        "https://starcraft2.com/en-us/profile/{region_id}/{subregion}/{toon_id}"
     )
 
     def __init__(self, uid, init_data):

--- a/test_replays/test_replays.py
+++ b/test_replays/test_replays.py
@@ -80,10 +80,10 @@ class TestReplays(unittest.TestCase):
         self.assertEqual(boom.result, "Loss")
 
         self.assertEqual(
-            emperor.url, "http://eu.battle.net/sc2/en/profile/520049/1/Emperor/"
+            emperor.url, "https://starcraft2.com/en-us/profile/2/1/520049"
         )
         self.assertEqual(
-            boom.url, "http://eu.battle.net/sc2/en/profile/1694745/1/Boom/"
+            boom.url, "https://starcraft2.com/en-us/profile/2/1/1694745"
         )
 
         self.assertEqual(len(replay.messages), 12)
@@ -163,10 +163,10 @@ class TestReplays(unittest.TestCase):
         reddawn = [player for player in replay.players if player.name == "reddawn"][0]
         self.assertEqual(
             shadesofgray.url,
-            "http://us.battle.net/sc2/en/profile/2358439/1/ShadesofGray/",
+            "https://starcraft2.com/en-us/profile/1/1/2358439",
         )
         self.assertEqual(
-            reddawn.url, "http://us.battle.net/sc2/en/profile/2198663/1/reddawn/"
+            reddawn.url, "https://starcraft2.com/en-us/profile/1/1/2198663"
         )
 
     def test_kr_realm_and_tampered_messages(self):
@@ -179,10 +179,10 @@ class TestReplays(unittest.TestCase):
         first = [player for player in replay.players if player.name == "명지대학교"][0]
         second = [player for player in replay.players if player.name == "티에스엘사기수"][0]
         self.assertEqual(
-            first.url, "http://kr.battle.net/sc2/en/profile/258945/1/명지대학교/"
+            first.url, "https://starcraft2.com/en-us/profile/3/1/258945"
         )
         self.assertEqual(
-            second.url, "http://kr.battle.net/sc2/en/profile/102472/1/티에스엘사기수/"
+            second.url, "https://starcraft2.com/en-us/profile/3/1/102472"
         )
         self.assertEqual(replay.messages[0].text, "sc2.replays.net")
         self.assertEqual(replay.messages[5].text, "sc2.replays.net")

--- a/test_replays/test_replays.py
+++ b/test_replays/test_replays.py
@@ -79,12 +79,8 @@ class TestReplays(unittest.TestCase):
         self.assertEqual(emperor.result, "Win")
         self.assertEqual(boom.result, "Loss")
 
-        self.assertEqual(
-            emperor.url, "https://starcraft2.com/en-us/profile/2/1/520049"
-        )
-        self.assertEqual(
-            boom.url, "https://starcraft2.com/en-us/profile/2/1/1694745"
-        )
+        self.assertEqual(emperor.url, "https://starcraft2.com/en-us/profile/2/1/520049")
+        self.assertEqual(boom.url, "https://starcraft2.com/en-us/profile/2/1/1694745")
 
         self.assertEqual(len(replay.messages), 12)
         self.assertEqual(replay.messages[0].text, "hf")
@@ -178,12 +174,8 @@ class TestReplays(unittest.TestCase):
         self.assertEqual(replay.expansion, "WoL")
         first = [player for player in replay.players if player.name == "명지대학교"][0]
         second = [player for player in replay.players if player.name == "티에스엘사기수"][0]
-        self.assertEqual(
-            first.url, "https://starcraft2.com/en-us/profile/3/1/258945"
-        )
-        self.assertEqual(
-            second.url, "https://starcraft2.com/en-us/profile/3/1/102472"
-        )
+        self.assertEqual(first.url, "https://starcraft2.com/en-us/profile/3/1/258945")
+        self.assertEqual(second.url, "https://starcraft2.com/en-us/profile/3/1/102472")
         self.assertEqual(replay.messages[0].text, "sc2.replays.net")
         self.assertEqual(replay.messages[5].text, "sc2.replays.net")
 


### PR DESCRIPTION
Old profile url will be redirected to the new profile url which starts with "starcraft2.com".