### PR TITLE
fix black formatting from StyleCheck 625

### DIFF
--- a/STYLE_GUIDE.rst
+++ b/STYLE_GUIDE.rst
@@ -1,11 +1,15 @@
 STYLE GUIDE
 ==============
 
-As a rough style guide, please lint your code with pep8::
+As a rough style guide, please lint your code with black, codespell, and flake8::
 
-    pip install pep8
-    pep8 --ignore E501,E226,E241 sc2reader
+    pip install black codespell flake8
+    codespell -L queenland,uint
+    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    black . --check
 
+More up-to-date checks may be detailed in `.circleci/config.yml`.
 
 All files should start with the following::
 
@@ -18,10 +22,7 @@ All files should start with the following::
 All imports should be absolute.
 
 
-All string formatting sound be done in the following style::
+All string formatting should be done in the following style::
 
     "my {0} formatted {1} string {2}".format("super", "python", "example")
     "the {x} style of {y} is also {z}".format(x="dict", y="arguments", z="acceptable")
-
-The format argument index numbers are important for 2.6 support. ``%`` formatting is not allowed for 3.x support
-

--- a/STYLE_GUIDE.rst
+++ b/STYLE_GUIDE.rst
@@ -21,8 +21,4 @@ All files should start with the following::
 
 All imports should be absolute.
 
-
-All string formatting should be done in the following style::
-
-    "my {0} formatted {1} string {2}".format("super", "python", "example")
-    "the {x} style of {y} is also {z}".format(x="dict", y="arguments", z="acceptable")
+All string formatting should be done with f-strings. See https://docs.python.org/3/reference/lexical_analysis.html#f-strings

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,8 +43,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"sc2reader"
-copyright = u"2011-2013"
+project = "sc2reader"
+copyright = "2011-2013"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -182,7 +182,7 @@ htmlhelp_basename = "sc2readerdoc"
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "sc2reader.tex", u"sc2reader Documentation", u"Graylin Kim", "manual")
+    ("index", "sc2reader.tex", "sc2reader Documentation", "Graylin Kim", "manual")
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -213,4 +213,4 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "sc2reader", u"sc2reader Documentation", [u"Graylin Kim"], 1)]
+man_pages = [("index", "sc2reader", "sc2reader Documentation", ["Graylin Kim"], 1)]

--- a/sc2reader/engine/plugins/creeptracker.py
+++ b/sc2reader/engine/plugins/creeptracker.py
@@ -173,7 +173,7 @@ class creep_tracker:
         # Sample a square area using the radius
         for x in range(-radius, radius):
             for y in range(-radius, radius):
-                if (x ** 2 + y ** 2) <= (radius * radius):
+                if (x**2 + y**2) <= (radius * radius):
                     output_coordinates.append((x, y))
         return output_coordinates
 

--- a/sc2reader/events/tracker.py
+++ b/sc2reader/events/tracker.py
@@ -17,7 +17,7 @@ class TrackerEvent(Event):
     def __init__(self, frames):
         #: The frame of the game this event was applied
         #: Ignore all but the lowest 32 bits of the frame
-        self.frame = frames % 2 ** 32
+        self.frame = frames % 2**32
 
         #: The second of the game (game time not real time) this event was applied
         self.second = self.frame >> 4

--- a/sc2reader/readers.py
+++ b/sc2reader/readers.py
@@ -561,7 +561,7 @@ class GameEventsReader_Base(object):
             )
 
     # Don't want to do this more than once
-    SINGLE_BIT_MASKS = [0x1 << i for i in range(2 ** 9)]
+    SINGLE_BIT_MASKS = [0x1 << i for i in range(2**9)]
 
     def read_selection_bitmask(self, data, mask_length):
         bits_left = mask_length

--- a/sc2reader/resources.py
+++ b/sc2reader/resources.py
@@ -421,11 +421,11 @@ class Replay(Resource):
         # the value required to get the adjusted timestamp. We know the upper
         # limit for any adjustment number so use that to distinguish between
         # the two cases.
-        if details["utc_adjustment"] < 10 ** 7 * 60 * 60 * 24:
-            self.time_zone = details["utc_adjustment"] / (10 ** 7 * 60 * 60)
+        if details["utc_adjustment"] < 10**7 * 60 * 60 * 24:
+            self.time_zone = details["utc_adjustment"] / (10**7 * 60 * 60)
         else:
             self.time_zone = (details["utc_adjustment"] - details["file_time"]) / (
-                10 ** 7 * 60 * 60
+                10**7 * 60 * 60
             )
 
         self.game_length = self.length

--- a/sc2reader/scripts/sc2replayer.py
+++ b/sc2reader/scripts/sc2replayer.py
@@ -28,7 +28,6 @@ try:
             termios.tcsetattr(fd, termios.TCSAFLUSH, oldterm)
             fcntl.fcntl(fd, fcntl.F_SETFL, oldflags)
 
-
 except ImportError as e:
     try:
         # Oops, we might be on windows, try this one

--- a/sc2reader/utils.py
+++ b/sc2reader/utils.py
@@ -45,7 +45,7 @@ def windows_to_unix(windows_time):
     # This windows timestamp measures the number of 100 nanosecond periods since
     # January 1st, 1601. First we subtract the number of nanosecond periods from
     # 1601-1970, then we divide by 10^7 to bring it back to seconds.
-    return int((windows_time - 116444735995904000) / 10 ** 7)
+    return int((windows_time - 116444735995904000) / 10**7)
 
 
 @loggable


### PR DESCRIPTION
Fixing the failure from https://app.circleci.com/pipelines/github/ggtracker/sc2reader/56/workflows/26b5f9e8-b09e-4b41-ac18-4dbc023efab1/jobs/625

I noticed this issue cropped up since we haven't specified a `black` version here https://github.com/ggtracker/sc2reader/blob/a38e266f10ef44ed3a5295fffc5766df853adf0a/.circleci/config.yml#L18

What do you guys think about letting it float as is versus specifying a version now that `black` is stable? https://github.com/psf/black/releases/tag/stable

I also updated the style guide docs a bit