### PR TITLE
Fixed Ravager and RavagerCocoon unit info.

### DIFF
--- a/sc2reader/data/unit_info.json
+++ b/sc2reader/data/unit_info.json
@@ -224,9 +224,15 @@
     },
     "ravager": {
       "is_army": true,
-      "minerals": 75,
-      "vespene": 25,
-      "supply": 2
+      "minerals": 100,
+      "vespene": 100,
+      "supply": 3
+    },
+    "ravagercocoon": {
+        "is_army": true,
+        "minerals": 100,
+        "vespene": 100,
+        "supply": 3
     },
     "roach": {
       "is_army": true,


### PR DESCRIPTION
I have been working on a major update to the Supply Module, and I need these fixes in unit_info.json in order to correctly resolve unit supply throughout the replay.