### PR TITLE
Added class CommandManagerStateEvent.

### DIFF
--- a/sc2reader/events/game.py
+++ b/sc2reader/events/game.py
@@ -400,6 +400,26 @@ class DataCommandEvent(CommandEvent):
 
 
 @loggable
+class CommandManagerStateEvent(GameEvent):
+    """
+    These events indicated that the last :class:`CommandEvent` called has been
+    called again.  For example, if you add three SCVs to an empty queue on a
+    Command Center, the first add will be generate a :class:`BasicCommandEvent`
+    and the two subsequent adds will each generate a
+    :class:`CommandManagerStateEvent`.
+    """
+
+    def __init__(self, frame, pid, data):
+        super(CommandManagerStateEvent, self).__init__(frame, pid)
+
+        #: Always 1?
+        self.state = data["state"]
+
+        #: An index identifying how many events of this type have been called
+        self.sequence = data["sequence"]
+
+
+@loggable
 class SelectionEvent(GameEvent):
     """
     Selection events are generated when ever the active selection of the

--- a/sc2reader/readers.py
+++ b/sc2reader/readers.py
@@ -1745,7 +1745,7 @@ class GameEventsReader_34784(GameEventsReader_27950):
                     self.command_manager_reset_event,
                 ),  # Re-using this old number
                 61: (None, self.trigger_hotkey_pressed_event),
-                103: (None, self.command_manager_state_event),
+                103: (CommandManagerStateEvent, self.command_manager_state_event),
                 104: (
                     UpdateTargetPointCommandEvent,
                     self.command_update_target_point_event,


### PR DESCRIPTION
As reported in #117 , repeated CommandEvents were not showing up in the events queue when they occurred.  When a CommandEvent is repeated, it is recorded as a CommandManagerStateEvent, presumably to save space.  Added a class so these are now available.

Also some minor reformatting from running Black.

Resolves #117 