### PR TITLE
force gameheart to exit if game is played in LotV

### DIFF
--- a/sc2reader/engine/plugins/gameheart.py
+++ b/sc2reader/engine/plugins/gameheart.py
@@ -34,6 +34,11 @@ class GameHeartNormalizer(object):
             yield PluginExit(self, code=0, details=dict())
             return
 
+        # Exit plugin if game is LOTV as LOTV games dont use GameHeart
+        if replay.expansion == "LotV":
+            yield PluginExit(self, code=0, details=dict())
+            return
+
         start_frame = -1
         actual_players = {}
         for event in replay.tracker_events:


### PR DESCRIPTION
See issue #170

Tested this and players are correctly noted as players rather than observers post-change.

The only thing with this method is the Void.SC2Mod dependency has to be used by the map to get identified as a LoTV map.

I was going to use base_build to determine if the plugin should exit, but was guessing that if someone were to go and play a HOTS map with gameheart enabled that it would have the current base_build and so wouldn't be parsed by this change even though it should... If you think thats a better method then I can update the pr.

If merged would it be possible to also get a release :)