### PR TITLE
Remove encoding option from JSON script.

### DIFF
--- a/sc2reader/scripts/sc2json.py
+++ b/sc2reader/scripts/sc2json.py
@@ -26,9 +26,7 @@ def main():
 
     factory = sc2reader.factories.SC2Factory()
     try:
-        factory.register_plugin(
-            "Replay", toJSON(indent=args.indent)
-        )
+        factory.register_plugin("Replay", toJSON(indent=args.indent))
     except TypeError:
         factory.register_plugin("Replay", toJSON(indent=args.indent))
     replay_json = factory.load_replay(args.path[0])

--- a/sc2reader/scripts/sc2json.py
+++ b/sc2reader/scripts/sc2json.py
@@ -16,13 +16,6 @@ def main():
         help="The per-line indent to use when printing a human readable json string",
     )
     parser.add_argument(
-        "--encoding",
-        "-e",
-        type=str,
-        default="UTF-8",
-        help="The character encoding use..",
-    )
-    parser.add_argument(
         "path",
         metavar="path",
         type=str,
@@ -34,8 +27,8 @@ def main():
     factory = sc2reader.factories.SC2Factory()
     try:
         factory.register_plugin(
-            "Replay", toJSON(encoding=args.encoding, indent=args.indent)
-        )  # legacy Python
+            "Replay", toJSON(indent=args.indent)
+        )
     except TypeError:
         factory.register_plugin("Replay", toJSON(indent=args.indent))
     replay_json = factory.load_replay(args.path[0])


### PR DESCRIPTION
Python3 deprecates encoding options in JSON.dumps and defaults to UTF8.