### PR TITLE
feat: add a plugin to correct all Event.second in lotv

### DIFF
--- a/sc2reader/engine/plugins/__init__.py
+++ b/sc2reader/engine/plugins/__init__.py
@@ -4,3 +4,5 @@ from sc2reader.engine.plugins.context import ContextLoader
 from sc2reader.engine.plugins.supply import SupplyTracker
 from sc2reader.engine.plugins.creeptracker import CreepTracker
 from sc2reader.engine.plugins.gameheart import GameHeartNormalizer
+
+from sc2reader.engine.plugins.lotv import EventSecondCorrector

--- a/sc2reader/engine/plugins/lotv/__init__.py
+++ b/sc2reader/engine/plugins/lotv/__init__.py
@@ -1,0 +1,1 @@
+from sc2reader.engine.plugins.lotv.event_second import EventSecondCorrector

--- a/sc2reader/engine/plugins/lotv/event_second.py
+++ b/sc2reader/engine/plugins/lotv/event_second.py
@@ -1,0 +1,20 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sc2reader.events import Event
+    from sc2reader.resources import Replay
+
+
+class EventSecondCorrector:
+    """
+    In Lotv, the game fps is 22.4, which means that the game time is not
+    accurate to the second. But the event.seconds is hardcoded as the fps
+    is 16. Since currently the replay build is not passed into the event,
+    the safest way to correct the event.seconds is use plugin.
+    """
+
+    name = "EventSecondCorrector"
+
+    def handleEvent(self, e: "Event", replay: "Replay"):
+        if 34784 <= replay.build:  # lotv replay, adjust time
+            e.second = int(e.second * 16 / 22.4)

--- a/sc2reader/objects.py
+++ b/sc2reader/objects.py
@@ -135,6 +135,9 @@ class Entity:
         toon_handle = self.toon_handle or "0-S2-0-0"
         parts = toon_handle.split("-")
 
+        #: The Battle.net region id the entity is registered to
+        self.region_id = int(parts[0])
+
         #: The Battle.net region the entity is registered to
         self.region = GATEWAY_LOOKUP[int(parts[0])]
 


### PR DESCRIPTION
All the Events.second now is calculated as frame / 16, which should be 22.4 in lotv. I believe this situation has been persistent for a long time, and many applications may rely on this working method. However, it is not conducive to new development work. I think adding a plugin to correct it might be the best option at the moment.