### PR TITLE
Feat: allow Observer.url

### DIFF
--- a/sc2reader/objects.py
+++ b/sc2reader/objects.py
@@ -135,6 +135,9 @@ class Entity:
         toon_handle = self.toon_handle or "0-S2-0-0"
         parts = toon_handle.split("-")
 
+        #: The Battle.net region id the entity is registered to
+        self.region_id = int(parts[0])
+
         #: The Battle.net region the entity is registered to
         self.region = GATEWAY_LOOKUP[int(parts[0])]
 

--- a/sc2reader/objects.py
+++ b/sc2reader/objects.py
@@ -139,7 +139,7 @@ class Entity:
         self.region_id = int(parts[0])
 
         #: The Battle.net region the entity is registered to
-        self.region = GATEWAY_LOOKUP[int(parts[0])]
+        self.region = GATEWAY_LOOKUP[self.region_id]
 
         #: The Battle.net subregion the entity is registered to
         self.subregion = int(parts[2])


### PR DESCRIPTION
**Before** this commit:
```
>>> o
Observer 4 - EnObsB
>>> o.url
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/daydrm/CodePlayground/python/sc2reader/sc2reader/objects.py", line 293, in url
    return self.URL_TEMPLATE.format(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'region_id'
```

**After** this commit:
```
>>> o = r.observer[4]
>>> o.url
'https://starcraft2.com/en-us/profile/2/1/10400173'
```