### PR TITLE
CircleCI: Test on Python 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,21 +2,22 @@ version: 2.0
 
 build_and_test: &build_and_test_steps
   - checkout
-  - run: sudo pip install --upgrade pip
-  - run: sudo pip install pytest -r requirements.txt
-  - run: pip install --user .
-  - run: python --version ; pip --version ; pwd ; ls -l
+  # Do not use `sudo pip`
+  # pipx is already installed but `pipx list` is empty
+  - run: python --version ; pip --version ; pipx --version ; pwd ; ls -l
+  - run: pip install pytest -r requirements.txt
+  - run: pip install --editable .
   - run: pytest
 
 
 jobs:
   StyleCheck:
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.11
     steps:
       - checkout
-      - run: sudo pip install black codespell flake8
       - run: python --version ; pip --version ; pwd ; ls -l
+      - run: pip install black codespell flake8 ruff
       - run: codespell -L queenland,uint
       # stop the build if there are Python syntax errors or undefined names
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -27,7 +28,7 @@ jobs:
 
   Python3:
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.11
     steps: *build_and_test_steps
 
 


### PR DESCRIPTION
https://circleci.com/docs/next-gen-migration-guide
```diff
-      - image: circleci/python:3.10
+      - image: cimg/python:3.11
```