### PR TITLE
Lint Python code with ruff instead of flake8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,9 @@ jobs:
     steps:
       - checkout
       - run: python --version ; pip --version ; pwd ; ls -l
-      - run: pip install black codespell flake8 ruff
+      - run: pip install black codespell ruff
       - run: codespell -L queenland,uint
-      # stop the build if there are Python syntax errors or undefined names
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - run: ruff .
       - run: black . --check
 
 

--- a/STYLE_GUIDE.rst
+++ b/STYLE_GUIDE.rst
@@ -1,12 +1,11 @@
 STYLE GUIDE
 ==============
 
-As a rough style guide, please lint your code with black, codespell, and flake8::
+As a rough style guide, please lint your code with black, codespell, and ruff::
 
-    pip install black codespell flake8
+    pip install black codespell ruff
     codespell -L queenland,uint
-    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    ruff .
     black . --check
 
 More up-to-date checks may be detailed in `.circleci/config.yml`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
+import sys
+
 import sc2reader
 
 autodoc_member_order = "bysource"

--- a/examples/sc2autosave.py
+++ b/examples/sc2autosave.py
@@ -192,8 +192,9 @@ def run(args):
                 replay = sc2reader.load_replay(path, load_level=2)
             except KeyboardInterrupt:
                 raise
-            except:
+            except Exception as e:
                 # Failure to parse
+                args.log.write(f"{e!r}")
                 file_name = os.path.basename(path)
                 directory = make_directory(args, ("parse_error",))
                 new_path = os.path.join(directory, file_name)

--- a/examples/sc2store.py
+++ b/examples/sc2store.py
@@ -11,8 +11,6 @@ import sc2reader
 
 from pprint import PrettyPrinter
 
-pprint = PrettyPrinter(indent=2).pprint
-
 from sqlalchemy import create_engine
 from sqlalchemy import Column, ForeignKey, distinct, Table
 from sqlalchemy import Integer, String, Sequence, DateTime
@@ -22,6 +20,8 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.associationproxy import association_proxy
+
+pprint = PrettyPrinter(indent=2).pprint
 
 Base = declarative_base()
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,8 @@
+ignore = [
+    "E402",  # Module level import not at top of file
+    "F401",  # module imported but unused; consider using `importlib.util.find_spec` to test for availability
+    "F403",  # Run `removestar` on this codebase
+    "F405",  # Run `removestar` on this codebase
+    "F841",  # Run `ruff --select=F841 --fix .`
+]
+line-length=129

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,4 @@
 ignore = [
-    "E402",  # Module level import not at top of file
     "F401",  # module imported but unused; consider using `importlib.util.find_spec` to test for availability
     "F403",  # Run `removestar` on this codebase
     "F405",  # Run `removestar` on this codebase

--- a/sc2reader/constants.py
+++ b/sc2reader/constants.py
@@ -1,3 +1,6 @@
+import json
+import pkgutil
+
 # These are found in Repack-MPQ/fileset.{locale}#Mods#Core.SC2Mod#{locale}.SC2Data/LocalizedData/Editor/EditorCategoryStrings.txt
 # EDSTR_CATEGORY_Race
 # EDSTR_PLAYERPROPS_RACE
@@ -100,9 +103,6 @@ SUBREGIONS = {
     "xx": {1: "xx"},
 }
 
-
-import json
-import pkgutil
 
 attributes_json = pkgutil.get_data("sc2reader.data", "attributes.json").decode("utf8")
 attributes_dict = json.loads(attributes_json)

--- a/sc2reader/engine/plugins/context.py
+++ b/sc2reader/engine/plugins/context.py
@@ -263,7 +263,7 @@ class ContextLoader:
             replay.datapack.change_type(event.unit, event.unit_type_name, event.frame)
         else:
             self.logger.error(
-                "Unit {} type changed at {} [{}] before it was born!".format(
+                "Unit {} type changed at {} before it was born!".format(
                     event.unit_id, Length(seconds=event.second)
                 )
             )

--- a/sc2reader/engine/plugins/selection.py
+++ b/sc2reader/engine/plugins/selection.py
@@ -76,7 +76,9 @@ class SelectionTracker:
 
         if mode == "Mask":
             # Deselect objects according to deselect mask
-            sfilter = lambda bit_u: not bit_u[0]
+            def sfilter(bit_u):
+                return not bit_u[0]
+
             mask = data + [False] * (selection_size - data_size)
             new_selection = [u for (bit, u) in filter(sfilter, zip(mask, selection))]
             error = data_size > selection_size

--- a/sc2reader/factories/plugins/replay.py
+++ b/sc2reader/factories/plugins/replay.py
@@ -85,7 +85,6 @@ def toDict(replay):
         "is_ladder": getattr(replay, "is_ladder", False),
         "is_private": getattr(replay, "is_private", False),
         "filename": getattr(replay, "filename", None),
-        "file_time": getattr(replay, "file_time", None),
         "frames": getattr(replay, "frames", None),
         "build": getattr(replay, "build", None),
         "release": getattr(replay, "release_string", None),

--- a/sc2reader/factories/sc2factory.py
+++ b/sc2reader/factories/sc2factory.py
@@ -266,13 +266,13 @@ class CachedSC2Factory(SC2Factory):
         return resource
 
     def cache_has(self, cache_key):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def cache_get(self, cache_key):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def cache_set(self, cache_key, value):
-        raise NotImplemented()
+        raise NotImplementedError()
 
 
 class FileCachedSC2Factory(CachedSC2Factory):

--- a/sc2reader/resources.py
+++ b/sc2reader/resources.py
@@ -1491,8 +1491,8 @@ class MapHeader(Resource):
 
         # Parse localization hashes
         l18n_struct = self.data[0][4][8]
-        for l in l18n_struct:
-            parsed_hash = utils.parse_hash(l[1][0])
-            self.localization_urls[l[0]] = utils.get_resource_url(
+        for h in l18n_struct:
+            parsed_hash = utils.parse_hash(h[1][0])
+            self.localization_urls[h[0]] = utils.get_resource_url(
                 parsed_hash["server"], parsed_hash["hash"], parsed_hash["type"]
             )

--- a/sc2reader/scripts/sc2replayer.py
+++ b/sc2reader/scripts/sc2replayer.py
@@ -32,7 +32,8 @@ except ImportError as e:
         from msvcrt import getch
     except ImportError as e:
         # We can't make getch happen, just dump events to the screen
-        getch = lambda: True
+        def getch():
+            return True
 
 
 import argparse

--- a/sc2reader/utils.py
+++ b/sc2reader/utils.py
@@ -163,11 +163,14 @@ def get_files(
 
     # If an extension is supplied, use it to do a type check
     if extension:
-        type_check = (
-            lambda path: os.path.splitext(path)[1][1:].lower() == extension.lower()
-        )
+
+        def type_check(path):
+            return os.path.splitext(path)[1][1:].lower() == extension.lower()
+
     else:
-        type_check = lambda n: True
+
+        def type_check(n):
+            return True
 
     # os.walk can't handle file paths, only directories
     if os.path.isfile(path):
@@ -315,7 +318,6 @@ def toDict(replay):
         "is_ladder": getattr(replay, "is_ladder", False),
         "is_private": getattr(replay, "is_private", False),
         "filename": getattr(replay, "filename", None),
-        "file_time": getattr(replay, "file_time", None),
         "frames": getattr(replay, "frames", None),
         "build": getattr(replay, "build", None),
         "release": getattr(replay, "release_string", None),


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 600 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

Manually fix these issues...
 % `ruff rule E402`  # Module level import not at top of file

% `ruff --select=E401,E722,E741,F524 .`
```
docs/source/conf.py:13:1: E401 Multiple imports on one line
examples/sc2autosave.py:195:13: E722 Do not use bare `except`
sc2reader/engine/plugins/context.py:266:17: F524 `.format` call is missing argument(s) for placeholder(s): 2
sc2reader/resources.py:1494:13: E741 Ambiguous variable name: `l`
Found 4 errors.
```

Use `ruff --fix` to fix these issues...
% `ruff --statistics .`
```
4	E731	[*] Do not assign a `lambda` expression, use a `def`
3	F901	[*] `raise NotImplemented` should be `raise NotImplementedError`
2	F601	[*] Dictionary key literal `"file_time"` repeated
```

% `ruff --fix .`
```
Found 9 errors (9 fixed, 0 remaining).
```