### PR TITLE
Python PEP8: Remove wildcard imports with explicit imports

### DIFF
--- a/sc2reader/engine/engine.py
+++ b/sc2reader/engine/engine.py
@@ -1,6 +1,12 @@
 import collections
-from sc2reader.events import (CommandEvent, ControlGroupEvent, Event, GameEvent, MessageEvent,
-                              TrackerEvent)
+from sc2reader.events import (
+    CommandEvent,
+    ControlGroupEvent,
+    Event,
+    GameEvent,
+    MessageEvent,
+    TrackerEvent,
+)
 from sc2reader.engine.events import InitGameEvent, EndGameEvent, PluginExit
 
 

--- a/sc2reader/engine/engine.py
+++ b/sc2reader/engine/engine.py
@@ -1,5 +1,6 @@
 import collections
-from sc2reader.events import *
+from sc2reader.events import (CommandEvent, ControlGroupEvent, Event, GameEvent, MessageEvent,
+                              TrackerEvent)
 from sc2reader.engine.events import InitGameEvent, EndGameEvent, PluginExit
 
 

--- a/sc2reader/objects.py
+++ b/sc2reader/objects.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 from sc2reader import utils, log_utils
 from sc2reader.decoders import ByteDecoder
-from sc2reader.constants import *
+from sc2reader.constants import GATEWAY_LOOKUP, LOBBY_PROPERTIES, LOCALIZED_RACES
 
 Location = namedtuple("Location", ["x", "y"])
 

--- a/sc2reader/readers.py
+++ b/sc2reader/readers.py
@@ -1,10 +1,17 @@
 import struct
 
 from sc2reader.exceptions import ParseError, ReadError
-from sc2reader.objects import *
-from sc2reader.events.game import *
-from sc2reader.events.message import *
-from sc2reader.events.tracker import *
+from sc2reader.objects import Attribute
+from sc2reader.events.game import (CameraEvent, CommandManagerStateEvent, HijackReplayGameEvent,
+                                   PlayerLeaveEvent, ResourceTradeEvent, SelectionEvent,
+                                   UpdateTargetPointCommandEvent, UpdateTargetUnitCommandEvent,
+                                   UserOptionsEvent, create_command_event,
+                                   create_control_group_event)
+from sc2reader.events.message import ChatEvent, PingEvent, ProgressEvent
+from sc2reader.events.tracker import (PlayerSetupEvent, PlayerStatsEvent, UnitBornEvent,
+                                      UnitDiedEvent, UnitDoneEvent, UnitInitEvent,
+                                      UnitOwnerChangeEvent, UnitPositionsEvent, UnitTypeChangeEvent,
+                                      UpgradeCompleteEvent)
 from sc2reader.utils import DepotFile
 from sc2reader.decoders import BitPackedDecoder, ByteDecoder
 

--- a/sc2reader/readers.py
+++ b/sc2reader/readers.py
@@ -2,16 +2,32 @@ import struct
 
 from sc2reader.exceptions import ParseError, ReadError
 from sc2reader.objects import Attribute
-from sc2reader.events.game import (CameraEvent, CommandManagerStateEvent, HijackReplayGameEvent,
-                                   PlayerLeaveEvent, ResourceTradeEvent, SelectionEvent,
-                                   UpdateTargetPointCommandEvent, UpdateTargetUnitCommandEvent,
-                                   UserOptionsEvent, create_command_event,
-                                   create_control_group_event)
+from sc2reader.events.game import (
+    CameraEvent,
+    CommandManagerStateEvent,
+    HijackReplayGameEvent,
+    PlayerLeaveEvent,
+    ResourceTradeEvent,
+    SelectionEvent,
+    UpdateTargetPointCommandEvent,
+    UpdateTargetUnitCommandEvent,
+    UserOptionsEvent,
+    create_command_event,
+    create_control_group_event,
+)
 from sc2reader.events.message import ChatEvent, PingEvent, ProgressEvent
-from sc2reader.events.tracker import (PlayerSetupEvent, PlayerStatsEvent, UnitBornEvent,
-                                      UnitDiedEvent, UnitDoneEvent, UnitInitEvent,
-                                      UnitOwnerChangeEvent, UnitPositionsEvent, UnitTypeChangeEvent,
-                                      UpgradeCompleteEvent)
+from sc2reader.events.tracker import (
+    PlayerSetupEvent,
+    PlayerStatsEvent,
+    UnitBornEvent,
+    UnitDiedEvent,
+    UnitDoneEvent,
+    UnitInitEvent,
+    UnitOwnerChangeEvent,
+    UnitPositionsEvent,
+    UnitTypeChangeEvent,
+    UpgradeCompleteEvent,
+)
 from sc2reader.utils import DepotFile
 from sc2reader.decoders import BitPackedDecoder, ByteDecoder
 

--- a/sc2reader/scripts/sc2replayer.py
+++ b/sc2reader/scripts/sc2replayer.py
@@ -37,7 +37,8 @@ except ImportError as e:
 
 import argparse
 import sc2reader
-from sc2reader.events import *
+from sc2reader.events import (CameraEvent, CommandEvent, GameStartEvent, PlayerLeaveEvent,
+                              SelectionEvent)
 
 
 def main():

--- a/sc2reader/scripts/sc2replayer.py
+++ b/sc2reader/scripts/sc2replayer.py
@@ -37,8 +37,14 @@ except ImportError as e:
 
 import argparse
 import sc2reader
-from sc2reader.events import (CameraEvent, CommandEvent, ControlGroupEvent,
-                              GameStartEvent, PlayerLeaveEvent, SelectionEvent)
+from sc2reader.events import (
+    CameraEvent,
+    CommandEvent,
+    ControlGroupEvent,
+    GameStartEvent,
+    PlayerLeaveEvent,
+    SelectionEvent,
+)
 
 
 def main():

--- a/sc2reader/scripts/sc2replayer.py
+++ b/sc2reader/scripts/sc2replayer.py
@@ -37,8 +37,8 @@ except ImportError as e:
 
 import argparse
 import sc2reader
-from sc2reader.events import (CameraEvent, CommandEvent, GameStartEvent, PlayerLeaveEvent,
-                              SelectionEvent)
+from sc2reader.events import (CameraEvent, CommandEvent, ControlGroupEvent,
+                              GameStartEvent, PlayerLeaveEvent, SelectionEvent)
 
 
 def main():
@@ -100,7 +100,7 @@ def main():
                 or isinstance(event, SelectionEvent)
                 or isinstance(event, PlayerLeaveEvent)
                 or isinstance(event, GameStartEvent)
-                or (args.hotkeys and isinstance(event, HotkeyEvent))
+                or (args.hotkeys and isinstance(event, ControlGroupEvent))
                 or (args.cameras and isinstance(event, CameraEvent))
             ):
                 print(event)


### PR DESCRIPTION
Replace `import *` imports in Python files with explicit imports.
% `pipx run removestar --in-place .`  # https://www.asmeurer.com/removestar

This change allowed our linter to find and fix an `undefined name`: `HotkeyEvent` --> `ControlGroupEvent`
```
F821 undefined name 'HotkeyEvent'
```
This would have raised `NameError` at runtime.
% `ruff rule F821`
# undefined-name (F821)

Derived from the **Pyflakes** linter.

## What it does
Checks for uses of undefined names.

## Why is this bad?
An undefined name is likely to raise `NameError` at runtime.

## Example
```python
def double():
    return n * 2  # raises `NameError` if `n` is undefined when `double` is called
```

Use instead:
```python
def double(n):
    return n * 2
```

## References
- [Python documentation: Naming and binding](https://docs.python.org/3/reference/executionmodel.html#naming-and-binding)