### PR TITLE
Fix division by zero on instant leave replays

### DIFF
--- a/sc2reader/factories/plugins/replay.py
+++ b/sc2reader/factories/plugins/replay.py
@@ -126,7 +126,7 @@ def APMTracker(replay):
             elif event.name == "PlayerLeaveEvent":
                 player.seconds_played = event.second
 
-        if len(player.apm) > 0:
+        if len(player.apm) > 0 and player.seconds_played > 0:
             player.avg_apm = (
                 sum(player.aps.values()) / float(player.seconds_played) * 60
             )


### PR DESCRIPTION
On an instant leave there can be a division by zero. 

If a player does an action and leaves the game just when the game clocks from second 0 to second 1 there can be a condition where apm > 0 but second == 0, resulting in a division by zero on line 131. 

Example replay:
[NeoHumanity LE (279).zip](https://github.com/ggtracker/sc2reader/files/13786910/NeoHumanity.LE.279.zip)
