### PR TITLE
Dialog control event

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - checkout
       - run: python --version ; pip --version ; pwd ; ls -l
       - run: pip install black codespell ruff
-      - run: codespell -L queenland,uint
+      - run: codespell -L queenland,uint,assertin
       - run: ruff .
       - run: black . --check
 

--- a/examples/sc2autosave.py
+++ b/examples/sc2autosave.py
@@ -77,16 +77,16 @@ without renaming to a 'Saved' subdirectory every 10 seconds. The depth 0 option
 keeps the script from looking into the 'Saved' subdirectory.
 
     sc2autosave                                                             \
-        --source ~/My\\ Documents/Starcraft\\ II/Accounts/.../Mutliplayer     \
-        --dest ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplater/Saved \
+        --source ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplayer     \
+        --dest ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplayer/Saved \
         --period 10                                                         \
         --depth 0
 
 This next configuration runs in batch mode using the default renaming format.
 
     sc2autosave                                                             \
-        --source ~/My\\ Documents/Starcraft\\ II/Accounts/.../Mutliplayer     \
-        --dest ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplater/Saved \
+        --source ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplayer     \
+        --dest ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplayer/Saved \
         --rename
 
     (ZvP) Lost Temple: ShadesofGray(Z) vs Trisfall(P).SC2Replay
@@ -96,8 +96,8 @@ Here is a heavily customized format that organizes replays into subdirectories
 by replay format and favors ShadesofGray in the player and team orderings.
 
     sc2autosave                                                             \
-        --source ~/My\\ Documents/Starcraft\\ II/Accounts/.../Mutliplayer     \
-        --dest ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplater/Saved \
+        --source ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplayer     \
+        --dest ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplayer/Saved \
         --rename "{:format}/{:matchup} on {:map}: {:teams}"                 \
         --player-format "{:name}({:play_race})"                             \
         --team-order-by number                                              \
@@ -112,8 +112,8 @@ strict player and team ordering by number with no exceptions and formats game
 length to show both minutes and seconds.
 
     sc2autosave                                                             \
-        --source ~/My\\ Documents/Starcraft\\ II/Accounts/.../Mutliplayer     \
-        --dest ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplater/Saved \
+        --source ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplayer     \
+        --dest ~/My\\ Documents/Starcraft\\ II/Accounts/.../Multiplayer/Saved \
         --rename "{:matchup}/({:length}) {:map}: {:teams}"                  \
         --player-format "{:name}({:play_race})"                             \
         --team-order-by number                                              \

--- a/sc2reader/engine/plugins/creeptracker.py
+++ b/sc2reader/engine/plugins/creeptracker.py
@@ -105,7 +105,7 @@ class creep_tracker:
     def __init__(self, replay):
         # if the debug option is selected, minimaps will be printed to a file
         ##and a stringIO containing the minimap image will be saved for
-        ##every minite in the game and the minimap with creep highlighted
+        ##every minute in the game and the minimap with creep highlighted
         ## will be printed out.
         self.debug = replay.opt["debug"]
         ##This list contains creep spread area for each player

--- a/sc2reader/engine/plugins/creeptracker.py
+++ b/sc2reader/engine/plugins/creeptracker.py
@@ -123,9 +123,9 @@ class creep_tracker:
         self.unit_name_to_radius = {"CreepTumor": 10, "Hatchery": 8, "NydusCanal": 5}
         self.radius_to_coordinates = dict()
         for x in self.unit_name_to_radius:
-            self.radius_to_coordinates[
-                self.unit_name_to_radius[x]
-            ] = self.radius_to_map_positions(self.unit_name_to_radius[x])
+            self.radius_to_coordinates[self.unit_name_to_radius[x]] = (
+                self.radius_to_map_positions(self.unit_name_to_radius[x])
+            )
         # Get map information
         replayMap = replay.map
         # extract image from replay package

--- a/sc2reader/events/game.py
+++ b/sc2reader/events/game.py
@@ -766,11 +766,13 @@ class HijackReplayGameEvent(GameEvent):
         #: Information on the users hijacking the game
         self.user_infos = data["user_infos"]
 
+
 @loggable
 class DialogControlEvent(GameEvent):
     """
     Generated when a dialog is interacted with.
     """
+
     def __init__(self, frame, pid, data):
         super().__init__(frame, pid)
 

--- a/sc2reader/events/game.py
+++ b/sc2reader/events/game.py
@@ -778,7 +778,7 @@ class DialogControlEvent(GameEvent):
         self.control_id = data["control_id"]
 
         #: How dialog was interacted with
-        self.event_type = self.data["event_type"]
+        self.event_type = data["event_type"]
 
         #: Data specific to event type such as changes or clicks
-        self.event_data = self.data["event_data"]
+        self.event_data = data["event_data"]

--- a/sc2reader/events/game.py
+++ b/sc2reader/events/game.py
@@ -765,3 +765,20 @@ class HijackReplayGameEvent(GameEvent):
 
         #: Information on the users hijacking the game
         self.user_infos = data["user_infos"]
+
+@loggable
+class DialogControlEvent(GameEvent):
+    """
+    Generated when a dialog is interacted with.
+    """
+    def __init__(self, frame, pid, data):
+        super().__init__(frame, pid)
+
+        #: Identifier for the dialog
+        self.control_id = data["control_id"]
+
+        #: How dialog was interacted with
+        self.event_type = self.data["event_type"]
+
+        #: Data specific to event type such as changes or clicks
+        self.event_data = self.data["event_data"]

--- a/sc2reader/readers.py
+++ b/sc2reader/readers.py
@@ -12,6 +12,7 @@ from sc2reader.events.game import (
     UpdateTargetPointCommandEvent,
     UpdateTargetUnitCommandEvent,
     UserOptionsEvent,
+    DialogControlEvent,
     create_command_event,
     create_control_group_event,
 )
@@ -462,7 +463,7 @@ class GameEventsReader_Base:
             52: (None, self.trigger_purchase_exit_event),
             53: (None, self.trigger_planet_mission_launched_event),
             54: (None, self.trigger_planet_panel_canceled_event),
-            55: (None, self.trigger_dialog_control_event),
+            55: (DialogControlEvent, self.trigger_dialog_control_event),
             56: (None, self.trigger_sound_length_sync_event),
             57: (None, self.trigger_conversation_skipped_event),
             58: (None, self.trigger_mouse_clicked_event),

--- a/sc2reader/readers.py
+++ b/sc2reader/readers.py
@@ -40,48 +40,68 @@ class InitDataReader:
             user_initial_data=[
                 dict(
                     name=data.read_aligned_string(data.read_uint8()),
-                    clan_tag=data.read_aligned_string(data.read_uint8())
-                    if replay.base_build >= 24764 and data.read_bool()
-                    else None,
-                    clan_logo=DepotFile(data.read_aligned_bytes(40))
-                    if replay.base_build >= 27950 and data.read_bool()
-                    else None,
-                    highest_league=data.read_uint8()
-                    if replay.base_build >= 24764 and data.read_bool()
-                    else None,
-                    combined_race_levels=data.read_uint32()
-                    if replay.base_build >= 24764 and data.read_bool()
-                    else None,
+                    clan_tag=(
+                        data.read_aligned_string(data.read_uint8())
+                        if replay.base_build >= 24764 and data.read_bool()
+                        else None
+                    ),
+                    clan_logo=(
+                        DepotFile(data.read_aligned_bytes(40))
+                        if replay.base_build >= 27950 and data.read_bool()
+                        else None
+                    ),
+                    highest_league=(
+                        data.read_uint8()
+                        if replay.base_build >= 24764 and data.read_bool()
+                        else None
+                    ),
+                    combined_race_levels=(
+                        data.read_uint32()
+                        if replay.base_build >= 24764 and data.read_bool()
+                        else None
+                    ),
                     random_seed=data.read_uint32(),
                     race_preference=data.read_uint8() if data.read_bool() else None,
-                    team_preference=data.read_uint8()
-                    if replay.base_build >= 16561 and data.read_bool()
-                    else None,
+                    team_preference=(
+                        data.read_uint8()
+                        if replay.base_build >= 16561 and data.read_bool()
+                        else None
+                    ),
                     test_map=data.read_bool(),
                     test_auto=data.read_bool(),
                     examine=data.read_bool() if replay.base_build >= 21955 else None,
-                    custom_interface=data.read_bool()
-                    if replay.base_build >= 24764
-                    else None,
-                    test_type=data.read_uint32()
-                    if replay.base_build >= 34784
-                    else None,
+                    custom_interface=(
+                        data.read_bool() if replay.base_build >= 24764 else None
+                    ),
+                    test_type=(
+                        data.read_uint32() if replay.base_build >= 34784 else None
+                    ),
                     observe=data.read_bits(2),
-                    hero=data.read_aligned_string(data.read_bits(9))
-                    if replay.base_build >= 34784
-                    else None,
-                    skin=data.read_aligned_string(data.read_bits(9))
-                    if replay.base_build >= 34784
-                    else None,
-                    mount=data.read_aligned_string(data.read_bits(9))
-                    if replay.base_build >= 34784
-                    else None,
-                    toon_handle=data.read_aligned_string(data.read_bits(7))
-                    if replay.base_build >= 34784
-                    else None,
-                    scaled_rating=data.read_uint32() - 2147483648
-                    if replay.base_build >= 54518 and data.read_bool()
-                    else None,
+                    hero=(
+                        data.read_aligned_string(data.read_bits(9))
+                        if replay.base_build >= 34784
+                        else None
+                    ),
+                    skin=(
+                        data.read_aligned_string(data.read_bits(9))
+                        if replay.base_build >= 34784
+                        else None
+                    ),
+                    mount=(
+                        data.read_aligned_string(data.read_bits(9))
+                        if replay.base_build >= 34784
+                        else None
+                    ),
+                    toon_handle=(
+                        data.read_aligned_string(data.read_bits(7))
+                        if replay.base_build >= 34784
+                        else None
+                    ),
+                    scaled_rating=(
+                        data.read_uint32() - 2147483648
+                        if replay.base_build >= 54518 and data.read_bool()
+                        else None
+                    ),
                 )
                 for i in range(data.read_bits(5))
             ],
@@ -95,27 +115,29 @@ class InitDataReader:
                     random_races=data.read_bool(),
                     battle_net=data.read_bool(),
                     amm=data.read_bool(),
-                    ranked=data.read_bool()
-                    if replay.base_build >= 34784 and replay.base_build < 38215
-                    else None,
+                    ranked=(
+                        data.read_bool()
+                        if replay.base_build >= 34784 and replay.base_build < 38215
+                        else None
+                    ),
                     competitive=data.read_bool(),
                     practice=data.read_bool() if replay.base_build >= 34784 else None,
-                    cooperative=data.read_bool()
-                    if replay.base_build >= 34784
-                    else None,
+                    cooperative=(
+                        data.read_bool() if replay.base_build >= 34784 else None
+                    ),
                     no_victory_or_defeat=data.read_bool(),
-                    hero_duplicates_allowed=data.read_bool()
-                    if replay.base_build >= 34784
-                    else None,
+                    hero_duplicates_allowed=(
+                        data.read_bool() if replay.base_build >= 34784 else None
+                    ),
                     fog=data.read_bits(2),
                     observers=data.read_bits(2),
                     user_difficulty=data.read_bits(2),
-                    client_debug_flags=data.read_uint64()
-                    if replay.base_build >= 22612
-                    else None,
-                    build_coach_enabled=data.read_bool()
-                    if replay.base_build >= 59587
-                    else None,
+                    client_debug_flags=(
+                        data.read_uint64() if replay.base_build >= 22612 else None
+                    ),
+                    build_coach_enabled=(
+                        data.read_bool() if replay.base_build >= 59587 else None
+                    ),
                 ),
                 game_speed=data.read_bits(3),
                 game_type=data.read_bits(3),
@@ -123,9 +145,11 @@ class InitDataReader:
                 max_observers=data.read_bits(5),
                 max_players=data.read_bits(5),
                 max_teams=data.read_bits(4) + 1,
-                max_colors=data.read_bits(6)
-                if replay.base_build >= 17266
-                else data.read_bits(5) + 1,
+                max_colors=(
+                    data.read_bits(6)
+                    if replay.base_build >= 17266
+                    else data.read_bits(5) + 1
+                ),
                 max_races=data.read_uint8() + 1,
                 max_controls=data.read_uint8()
                 + (0 if replay.base_build >= 26490 else 1),
@@ -142,36 +166,40 @@ class InitDataReader:
                         allowedDifficulty=data.read_bits(data.read_bits(6)),
                         allowedControls=data.read_bits(data.read_uint8()),
                         allowed_observe_types=data.read_bits(data.read_bits(2)),
-                        allowed_ai_builds=data.read_bits(
-                            data.read_bits(8 if replay.base_build >= 38749 else 7)
-                        )
-                        if replay.base_build >= 23925
-                        else None,
+                        allowed_ai_builds=(
+                            data.read_bits(
+                                data.read_bits(8 if replay.base_build >= 38749 else 7)
+                            )
+                            if replay.base_build >= 23925
+                            else None
+                        ),
                     )
                     for i in range(data.read_bits(5))
                 ],
                 default_difficulty=data.read_bits(6),
-                default_ai_build=data.read_bits(8 if replay.base_build >= 38749 else 7)
-                if replay.base_build >= 23925
-                else None,
+                default_ai_build=(
+                    data.read_bits(8 if replay.base_build >= 38749 else 7)
+                    if replay.base_build >= 23925
+                    else None
+                ),
                 cache_handles=[
                     DepotFile(data.read_aligned_bytes(40))
                     for i in range(
                         data.read_bits(6 if replay.base_build >= 21955 else 4)
                     )
                 ],
-                has_extension_mod=data.read_bool()
-                if replay.base_build >= 27950
-                else None,
-                has_nonBlizzardExtensionMod=data.read_bool()
-                if replay.base_build >= 42932
-                else None,
+                has_extension_mod=(
+                    data.read_bool() if replay.base_build >= 27950 else None
+                ),
+                has_nonBlizzardExtensionMod=(
+                    data.read_bool() if replay.base_build >= 42932 else None
+                ),
                 is_blizzardMap=data.read_bool(),
                 is_premade_ffa=data.read_bool(),
                 is_coop_mode=data.read_bool() if replay.base_build >= 23925 else None,
-                is_realtime_mode=data.read_bool()
-                if replay.base_build >= 54518
-                else None,
+                is_realtime_mode=(
+                    data.read_bool() if replay.base_build >= 54518 else None
+                ),
             ),
             lobby_state=dict(
                 phase=data.read_bits(3),
@@ -185,131 +213,158 @@ class InitDataReader:
                         colorPref=data.read_bits(5) if data.read_bool() else None,
                         race_pref=data.read_uint8() if data.read_bool() else None,
                         difficulty=data.read_bits(6),
-                        ai_build=data.read_bits(8 if replay.base_build >= 38749 else 7)
-                        if replay.base_build >= 23925
-                        else None,
+                        ai_build=(
+                            data.read_bits(8 if replay.base_build >= 38749 else 7)
+                            if replay.base_build >= 23925
+                            else None
+                        ),
                         handicap=data.read_bits(
                             32 if replay.base_build >= 80669 else 7
                         ),
                         observe=data.read_bits(2),
-                        logo_index=data.read_uint32()
-                        if replay.base_build >= 32283
-                        else None,
-                        hero=data.read_aligned_string(data.read_bits(9))
-                        if replay.base_build >= 34784
-                        else None,
-                        skin=data.read_aligned_string(data.read_bits(9))
-                        if replay.base_build >= 34784
-                        else None,
-                        mount=data.read_aligned_string(data.read_bits(9))
-                        if replay.base_build >= 34784
-                        else None,
-                        artifacts=[
-                            dict(
-                                type_struct=data.read_aligned_string(data.read_bits(9))
-                            )
-                            for i in range(data.read_bits(4))
-                        ]
-                        if replay.base_build >= 34784
-                        else None,
-                        working_set_slot_id=data.read_uint8()
-                        if replay.base_build >= 24764 and data.read_bool()
-                        else None,
+                        logo_index=(
+                            data.read_uint32() if replay.base_build >= 32283 else None
+                        ),
+                        hero=(
+                            data.read_aligned_string(data.read_bits(9))
+                            if replay.base_build >= 34784
+                            else None
+                        ),
+                        skin=(
+                            data.read_aligned_string(data.read_bits(9))
+                            if replay.base_build >= 34784
+                            else None
+                        ),
+                        mount=(
+                            data.read_aligned_string(data.read_bits(9))
+                            if replay.base_build >= 34784
+                            else None
+                        ),
+                        artifacts=(
+                            [
+                                dict(
+                                    type_struct=data.read_aligned_string(
+                                        data.read_bits(9)
+                                    )
+                                )
+                                for i in range(data.read_bits(4))
+                            ]
+                            if replay.base_build >= 34784
+                            else None
+                        ),
+                        working_set_slot_id=(
+                            data.read_uint8()
+                            if replay.base_build >= 24764 and data.read_bool()
+                            else None
+                        ),
                         rewards=[
                             data.read_uint32()
                             for i in range(
                                 data.read_bits(
                                     17
                                     if replay.base_build >= 34784
-                                    else 6
-                                    if replay.base_build >= 24764
-                                    else 5
+                                    else 6 if replay.base_build >= 24764 else 5
                                 )
                             )
                         ],
-                        toon_handle=data.read_aligned_string(data.read_bits(7))
-                        if replay.base_build >= 17266
-                        else None,
-                        licenses=[
-                            data.read_uint32()
-                            for i in range(
-                                data.read_bits(
-                                    16
-                                    if replay.base_build >= 77379
-                                    else 13
-                                    if replay.base_build >= 70154
-                                    else 9
-                                )
-                            )
-                        ]
-                        if replay.base_build >= 19132
-                        else [],
-                        tandem_leader_user_id=data.read_bits(4)
-                        if replay.base_build >= 34784 and data.read_bool()
-                        else None,
-                        commander=data.read_aligned_bytes(data.read_bits(9))
-                        if replay.base_build >= 34784
-                        else None,
-                        commander_level=data.read_uint32()
-                        if replay.base_build >= 36442
-                        else None,
-                        has_silence_penalty=data.read_bool()
-                        if replay.base_build >= 38215
-                        else None,
-                        tandem_id=data.read_bits(4)
-                        if replay.base_build >= 39576 and data.read_bool()
-                        else None,
-                        commander_mastery_level=data.read_uint32()
-                        if replay.base_build >= 42932
-                        else None,
-                        commander_mastery_talents=[
-                            data.read_uint32() for i in range(data.read_bits(3))
-                        ]
-                        if replay.base_build >= 42932
-                        else None,
-                        trophy_id=data.read_uint32()
-                        if replay.base_build >= 75689
-                        else None,
-                        reward_overrides=[
+                        toon_handle=(
+                            data.read_aligned_string(data.read_bits(7))
+                            if replay.base_build >= 17266
+                            else None
+                        ),
+                        licenses=(
                             [
-                                data.read_uint32(),
-                                [data.read_uint32() for i in range(data.read_bits(17))],
+                                data.read_uint32()
+                                for i in range(
+                                    data.read_bits(
+                                        16
+                                        if replay.base_build >= 77379
+                                        else 13 if replay.base_build >= 70154 else 9
+                                    )
+                                )
                             ]
-                            for j in range(data.read_bits(17))
-                        ]
-                        if replay.base_build >= 47185
-                        else None,
-                        brutal_plus_difficulty=data.read_uint32()
-                        if replay.base_build >= 77379
-                        else None,
-                        retry_mutation_indexes=[
-                            data.read_uint32() for i in range(data.read_bits(3))
-                        ]
-                        if replay.base_build >= 77379
-                        else None,
-                        ac_enemy_race=data.read_uint32()
-                        if replay.base_build >= 77379
-                        else None,
-                        ac_enemy_wave_type=data.read_uint32()
-                        if replay.base_build >= 77379
-                        else None,
-                        selected_commander_prestige=data.read_uint32()
-                        if replay.base_build >= 80871
-                        else None,
+                            if replay.base_build >= 19132
+                            else []
+                        ),
+                        tandem_leader_user_id=(
+                            data.read_bits(4)
+                            if replay.base_build >= 34784 and data.read_bool()
+                            else None
+                        ),
+                        commander=(
+                            data.read_aligned_bytes(data.read_bits(9))
+                            if replay.base_build >= 34784
+                            else None
+                        ),
+                        commander_level=(
+                            data.read_uint32() if replay.base_build >= 36442 else None
+                        ),
+                        has_silence_penalty=(
+                            data.read_bool() if replay.base_build >= 38215 else None
+                        ),
+                        tandem_id=(
+                            data.read_bits(4)
+                            if replay.base_build >= 39576 and data.read_bool()
+                            else None
+                        ),
+                        commander_mastery_level=(
+                            data.read_uint32() if replay.base_build >= 42932 else None
+                        ),
+                        commander_mastery_talents=(
+                            [data.read_uint32() for i in range(data.read_bits(3))]
+                            if replay.base_build >= 42932
+                            else None
+                        ),
+                        trophy_id=(
+                            data.read_uint32() if replay.base_build >= 75689 else None
+                        ),
+                        reward_overrides=(
+                            [
+                                [
+                                    data.read_uint32(),
+                                    [
+                                        data.read_uint32()
+                                        for i in range(data.read_bits(17))
+                                    ],
+                                ]
+                                for j in range(data.read_bits(17))
+                            ]
+                            if replay.base_build >= 47185
+                            else None
+                        ),
+                        brutal_plus_difficulty=(
+                            data.read_uint32() if replay.base_build >= 77379 else None
+                        ),
+                        retry_mutation_indexes=(
+                            [data.read_uint32() for i in range(data.read_bits(3))]
+                            if replay.base_build >= 77379
+                            else None
+                        ),
+                        ac_enemy_race=(
+                            data.read_uint32() if replay.base_build >= 77379 else None
+                        ),
+                        ac_enemy_wave_type=(
+                            data.read_uint32() if replay.base_build >= 77379 else None
+                        ),
+                        selected_commander_prestige=(
+                            data.read_uint32() if replay.base_build >= 80871 else None
+                        ),
                     )
                     for i in range(data.read_bits(5))
                 ],
                 random_seed=data.read_uint32(),
                 host_user_id=data.read_bits(4) if data.read_bool() else None,
                 is_single_player=data.read_bool(),
-                picked_map_tag=data.read_uint8()
-                if replay.base_build >= 36442
-                else None,
+                picked_map_tag=(
+                    data.read_uint8() if replay.base_build >= 36442 else None
+                ),
                 game_duration=data.read_uint32(),
                 default_difficulty=data.read_bits(6),
-                default_ai_build=data.read_bits(8 if replay.base_build >= 38749 else 7)
-                if replay.base_build >= 24764
-                else None,
+                default_ai_build=(
+                    data.read_bits(8 if replay.base_build >= 38749 else 7)
+                    if replay.base_build >= 24764
+                    else None
+                ),
             ),
         )
         if not data.done():
@@ -357,9 +412,9 @@ class DetailsReader:
                     observe=p[7],
                     result=p[8],
                     working_set_slot=p[9] if replay.build >= 24764 else None,
-                    hero=p[10]
-                    if replay.build >= 34784 and 10 in p
-                    else None,  # hero appears to be present in Heroes replays but not StarCraft 2 replays
+                    hero=(
+                        p[10] if replay.build >= 34784 and 10 in p else None
+                    ),  # hero appears to be present in Heroes replays but not StarCraft 2 replays
                 )
                 for p in details[0]
             ],
@@ -376,9 +431,11 @@ class DetailsReader:
             mini_save=details[11],
             game_speed=details[12],
             default_difficulty=details[13],
-            mod_paths=details[14]
-            if (replay.build >= 22612 and replay.versions[1] == 1)
-            else None,
+            mod_paths=(
+                details[14]
+                if (replay.build >= 22612 and replay.versions[1] == 1)
+                else None
+            ),
             campaign_index=details[15] if replay.versions[1] == 2 else None,
             restartAsTransitionMap=details[16] if replay.build > 26490 else None,
         )
@@ -739,9 +796,11 @@ class GameEventsReader_15405(GameEventsReader_Base):
         return dict(
             control_group_index=data.read_bits(4),
             control_group_update=data.read_bits(2),
-            remove_mask=("Mask", self.read_selection_bitmask(data, data.read_uint8()))
-            if data.read_bool()
-            else ("None", None),
+            remove_mask=(
+                ("Mask", self.read_selection_bitmask(data, data.read_uint8()))
+                if data.read_bool()
+                else ("None", None)
+            ),
         )
 
     def selection_sync_check_event(self, data):
@@ -1004,13 +1063,17 @@ class GameEventsReader_16561(GameEventsReader_15405):
     def command_event(self, data):
         return dict(
             flags=data.read_bits(17),
-            ability=dict(
-                ability_link=data.read_uint16(),
-                ability_command_index=data.read_bits(5),
-                ability_command_data=data.read_uint8() if data.read_bool() else None,
-            )
-            if data.read_bool()
-            else None,
+            ability=(
+                dict(
+                    ability_link=data.read_uint16(),
+                    ability_command_index=data.read_bits(5),
+                    ability_command_data=(
+                        data.read_uint8() if data.read_bool() else None
+                    ),
+                )
+                if data.read_bool()
+                else None
+            ),
             data={  # Choice
                 0: lambda: ("None", None),
                 1: lambda: (
@@ -1031,9 +1094,9 @@ class GameEventsReader_16561(GameEventsReader_15405):
                         unit_tag=data.read_uint32(),
                         unit_link=data.read_uint16(),
                         control_player_id=None,
-                        upkeep_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
+                        upkeep_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
                         point=dict(
                             x=data.read_bits(20),
                             y=data.read_bits(20),
@@ -1159,13 +1222,17 @@ class GameEventsReader_18574(GameEventsReader_18092):
     def command_event(self, data):
         return dict(
             flags=data.read_bits(18),
-            ability=dict(
-                ability_link=data.read_uint16(),
-                ability_command_index=data.read_bits(5),
-                ability_command_data=data.read_uint8() if data.read_bool() else None,
-            )
-            if data.read_bool()
-            else None,
+            ability=(
+                dict(
+                    ability_link=data.read_uint16(),
+                    ability_command_index=data.read_bits(5),
+                    ability_command_data=(
+                        data.read_uint8() if data.read_bool() else None
+                    ),
+                )
+                if data.read_bool()
+                else None
+            ),
             data={  # Choice
                 0: lambda: ("None", None),
                 1: lambda: (
@@ -1186,9 +1253,9 @@ class GameEventsReader_18574(GameEventsReader_18092):
                         unit_tag=data.read_uint32(),
                         unit_link=data.read_uint16(),
                         control_player_id=None,
-                        upkeep_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
+                        upkeep_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
                         point=dict(
                             x=data.read_bits(20),
                             y=data.read_bits(20),
@@ -1210,13 +1277,17 @@ class GameEventsReader_19595(GameEventsReader_19132):
     def command_event(self, data):
         return dict(
             flags=data.read_bits(18),
-            ability=dict(
-                ability_link=data.read_uint16(),
-                ability_command_index=data.read_bits(5),
-                ability_command_data=data.read_uint8() if data.read_bool() else None,
-            )
-            if data.read_bool()
-            else None,
+            ability=(
+                dict(
+                    ability_link=data.read_uint16(),
+                    ability_command_index=data.read_bits(5),
+                    ability_command_data=(
+                        data.read_uint8() if data.read_bool() else None
+                    ),
+                )
+                if data.read_bool()
+                else None
+            ),
             data={  # Choice
                 0: lambda: ("None", None),
                 1: lambda: (
@@ -1236,12 +1307,12 @@ class GameEventsReader_19595(GameEventsReader_19132):
                         timer=data.read_uint8(),
                         unit_tag=data.read_uint32(),
                         unit_link=data.read_uint16(),
-                        control_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
-                        upkeep_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
+                        control_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
+                        upkeep_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
                         point=dict(
                             x=data.read_bits(20),
                             y=data.read_bits(20),
@@ -1307,13 +1378,17 @@ class GameEventsReader_22612(GameEventsReader_21029):
     def command_event(self, data):
         return dict(
             flags=data.read_bits(20),
-            ability=dict(
-                ability_link=data.read_uint16(),
-                ability_command_index=data.read_bits(5),
-                ability_command_data=data.read_uint8() if data.read_bool() else None,
-            )
-            if data.read_bool()
-            else None,
+            ability=(
+                dict(
+                    ability_link=data.read_uint16(),
+                    ability_command_index=data.read_bits(5),
+                    ability_command_data=(
+                        data.read_uint8() if data.read_bool() else None
+                    ),
+                )
+                if data.read_bool()
+                else None
+            ),
             data={  # Choice
                 0: lambda: ("None", None),
                 1: lambda: (
@@ -1333,12 +1408,12 @@ class GameEventsReader_22612(GameEventsReader_21029):
                         timer=data.read_uint8(),
                         unit_tag=data.read_uint32(),
                         unit_link=data.read_uint16(),
-                        control_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
-                        upkeep_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
+                        control_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
+                        upkeep_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
                         point=dict(
                             x=data.read_bits(20),
                             y=data.read_bits(20),
@@ -1544,9 +1619,11 @@ class GameEventsReader_HotSBeta(GameEventsReader_23260):
 
     def camera_update_event(self, data):
         return dict(
-            target=dict(x=data.read_uint16(), y=data.read_uint16())
-            if data.read_bool()
-            else None,
+            target=(
+                dict(x=data.read_uint16(), y=data.read_uint16())
+                if data.read_bool()
+                else None
+            ),
             distance=data.read_uint16() if data.read_bool() else None,
             pitch=data.read_uint16() if data.read_bool() else None,
             yaw=data.read_uint16() if data.read_bool() else None,
@@ -1618,12 +1695,16 @@ class GameEventsReader_24247(GameEventsReader_HotSBeta):
                     game_user_id=data.read_bits(4),
                     observe=data.read_bits(2),
                     name=data.read_aligned_string(data.read_uint8()),
-                    toon_handle=data.read_aligned_string(data.read_bits(7))
-                    if data.read_bool()
-                    else None,
-                    clan_tag=data.read_aligned_string(data.read_uint8())
-                    if data.read_bool()
-                    else None,
+                    toon_handle=(
+                        data.read_aligned_string(data.read_bits(7))
+                        if data.read_bool()
+                        else None
+                    ),
+                    clan_tag=(
+                        data.read_aligned_string(data.read_uint8())
+                        if data.read_bool()
+                        else None
+                    ),
                     clan_logo=None,
                 )
                 for i in range(data.read_bits(5))
@@ -1633,9 +1714,11 @@ class GameEventsReader_24247(GameEventsReader_HotSBeta):
 
     def camera_update_event(self, data):
         return dict(
-            target=dict(x=data.read_uint16(), y=data.read_uint16())
-            if data.read_bool()
-            else None,
+            target=(
+                dict(x=data.read_uint16(), y=data.read_uint16())
+                if data.read_bool()
+                else None
+            ),
             distance=data.read_uint16() if data.read_bool() else None,
             pitch=data.read_uint16() if data.read_bool() else None,
             yaw=data.read_uint16() if data.read_bool() else None,
@@ -1656,12 +1739,16 @@ class GameEventsReader_24247(GameEventsReader_HotSBeta):
         return dict(
             observe=data.read_bits(2),
             name=data.read_aligned_string(data.read_bits(8)),
-            toon_handle=data.read_aligned_string(data.read_bits(7))
-            if data.read_bool()
-            else None,
-            clan_tag=data.read_aligned_string(data.read_uint8())
-            if data.read_bool()
-            else None,
+            toon_handle=(
+                data.read_aligned_string(data.read_bits(7))
+                if data.read_bool()
+                else None
+            ),
+            clan_tag=(
+                data.read_aligned_string(data.read_uint8())
+                if data.read_bool()
+                else None
+            ),
             clan_log=None,
         )
 
@@ -1713,15 +1800,21 @@ class GameEventsReader_27950(GameEventsReader_26490):
                     game_user_id=data.read_bits(4),
                     observe=data.read_bits(2),
                     name=data.read_aligned_string(data.read_uint8()),
-                    toon_handle=data.read_aligned_string(data.read_bits(7))
-                    if data.read_bool()
-                    else None,
-                    clan_tag=data.read_aligned_string(data.read_uint8())
-                    if data.read_bool()
-                    else None,
-                    clan_logo=DepotFile(data.read_aligned_bytes(40))
-                    if data.read_bool()
-                    else None,
+                    toon_handle=(
+                        data.read_aligned_string(data.read_bits(7))
+                        if data.read_bool()
+                        else None
+                    ),
+                    clan_tag=(
+                        data.read_aligned_string(data.read_uint8())
+                        if data.read_bool()
+                        else None
+                    ),
+                    clan_logo=(
+                        DepotFile(data.read_aligned_bytes(40))
+                        if data.read_bool()
+                        else None
+                    ),
                 )
                 for i in range(data.read_bits(5))
             ],
@@ -1730,9 +1823,11 @@ class GameEventsReader_27950(GameEventsReader_26490):
 
     def camera_update_event(self, data):
         return dict(
-            target=dict(x=data.read_uint16(), y=data.read_uint16())
-            if data.read_bool()
-            else None,
+            target=(
+                dict(x=data.read_uint16(), y=data.read_uint16())
+                if data.read_bool()
+                else None
+            ),
             distance=data.read_uint16() if data.read_bool() else None,
             pitch=data.read_uint16() if data.read_bool() else None,
             yaw=data.read_uint16() if data.read_bool() else None,
@@ -1743,15 +1838,19 @@ class GameEventsReader_27950(GameEventsReader_26490):
         return dict(
             observe=data.read_bits(2),
             name=data.read_aligned_string(data.read_bits(8)),
-            toon_handle=data.read_aligned_string(data.read_bits(7))
-            if data.read_bool()
-            else None,
-            clan_tag=data.read_aligned_string(data.read_uint8())
-            if data.read_bool()
-            else None,
-            clan_logo=DepotFile(data.read_aligned_bytes(40))
-            if data.read_bool()
-            else None,
+            toon_handle=(
+                data.read_aligned_string(data.read_bits(7))
+                if data.read_bool()
+                else None
+            ),
+            clan_tag=(
+                data.read_aligned_string(data.read_uint8())
+                if data.read_bool()
+                else None
+            ),
+            clan_logo=(
+                DepotFile(data.read_aligned_bytes(40)) if data.read_bool() else None
+            ),
         )
 
 
@@ -1871,13 +1970,17 @@ class GameEventsReader_34784(GameEventsReader_27950):
     def command_event(self, data):
         return dict(
             flags=data.read_bits(23),
-            ability=dict(
-                ability_link=data.read_uint16(),
-                ability_command_index=data.read_bits(5),
-                ability_command_data=data.read_uint8() if data.read_bool() else None,
-            )
-            if data.read_bool()
-            else None,
+            ability=(
+                dict(
+                    ability_link=data.read_uint16(),
+                    ability_command_index=data.read_bits(5),
+                    ability_command_data=(
+                        data.read_uint8() if data.read_bool() else None
+                    ),
+                )
+                if data.read_bool()
+                else None
+            ),
             data={  # Choice
                 0: lambda: ("None", None),
                 1: lambda: (
@@ -1897,12 +2000,12 @@ class GameEventsReader_34784(GameEventsReader_27950):
                         timer=data.read_uint8(),
                         unit_tag=data.read_uint32(),
                         unit_link=data.read_uint16(),
-                        control_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
-                        upkeep_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
+                        control_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
+                        upkeep_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
                         point=dict(
                             x=data.read_bits(20),
                             y=data.read_bits(20),
@@ -1949,9 +2052,11 @@ class GameEventsReader_34784(GameEventsReader_27950):
 
     def camera_update_event(self, data):
         return dict(
-            target=dict(x=data.read_uint16(), y=data.read_uint16())
-            if data.read_bool()
-            else None,
+            target=(
+                dict(x=data.read_uint16(), y=data.read_uint16())
+                if data.read_bool()
+                else None
+            ),
             distance=data.read_uint16() if data.read_bool() else None,
             pitch=data.read_uint16() if data.read_bool() else None,
             yaw=data.read_uint16() if data.read_bool() else None,
@@ -1966,15 +2071,19 @@ class GameEventsReader_34784(GameEventsReader_27950):
         return dict(
             observe=data.read_bits(2),
             name=data.read_aligned_string(data.read_bits(8)),
-            toon_handle=data.read_aligned_string(data.read_bits(7))
-            if data.read_bool()
-            else None,
-            clan_tag=data.read_aligned_string(data.read_uint8())
-            if data.read_bool()
-            else None,
-            clan_logo=DepotFile(data.read_aligned_bytes(40))
-            if data.read_bool()
-            else None,
+            toon_handle=(
+                data.read_aligned_string(data.read_bits(7))
+                if data.read_bool()
+                else None
+            ),
+            clan_tag=(
+                data.read_aligned_string(data.read_uint8())
+                if data.read_bool()
+                else None
+            ),
+            clan_logo=(
+                DepotFile(data.read_aligned_bytes(40)) if data.read_bool() else None
+            ),
             hijack=data.read_bool(),
             hijack_clone_game_user_id=data.read_bits(4) if data.read_bool() else None,
         )
@@ -2020,13 +2129,17 @@ class GameEventsReader_38215(GameEventsReader_36442):
     def trigger_command_error_event(self, data):
         return dict(
             error=data.read_uint32() - 2147483648,
-            ability=dict(
-                ability_link=data.read_uint16(),
-                ability_command_index=data.read_bits(5),
-                ability_command_data=data.read_uint8() if data.read_bool() else None,
-            )
-            if data.read_bool()
-            else None,
+            ability=(
+                dict(
+                    ability_link=data.read_uint16(),
+                    ability_command_index=data.read_bits(5),
+                    ability_command_data=(
+                        data.read_uint8() if data.read_bool() else None
+                    ),
+                )
+                if data.read_bool()
+                else None
+            ),
         )
 
     def trigger_mousewheel_event(self, data):
@@ -2041,13 +2154,17 @@ class GameEventsReader_38215(GameEventsReader_36442):
         # with the only change being that flags now has 25 bits instead of 23.
         return dict(
             flags=data.read_bits(25),
-            ability=dict(
-                ability_link=data.read_uint16(),
-                ability_command_index=data.read_bits(5),
-                ability_command_data=data.read_uint8() if data.read_bool() else None,
-            )
-            if data.read_bool()
-            else None,
+            ability=(
+                dict(
+                    ability_link=data.read_uint16(),
+                    ability_command_index=data.read_bits(5),
+                    ability_command_data=(
+                        data.read_uint8() if data.read_bool() else None
+                    ),
+                )
+                if data.read_bool()
+                else None
+            ),
             data={  # Choice
                 0: lambda: ("None", None),
                 1: lambda: (
@@ -2067,12 +2184,12 @@ class GameEventsReader_38215(GameEventsReader_36442):
                         timer=data.read_uint8(),
                         unit_tag=data.read_uint32(),
                         unit_link=data.read_uint16(),
-                        control_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
-                        upkeep_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
+                        control_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
+                        upkeep_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
                         point=dict(
                             x=data.read_bits(20),
                             y=data.read_bits(20),
@@ -2155,13 +2272,17 @@ class GameEventsReader_64469(GameEventsReader_38996):
     def command_event(self, data):
         return dict(
             flags=data.read_bits(26),
-            ability=dict(
-                ability_link=data.read_uint16(),
-                ability_command_index=data.read_bits(5),
-                ability_command_data=data.read_uint8() if data.read_bool() else None,
-            )
-            if data.read_bool()
-            else None,
+            ability=(
+                dict(
+                    ability_link=data.read_uint16(),
+                    ability_command_index=data.read_bits(5),
+                    ability_command_data=(
+                        data.read_uint8() if data.read_bool() else None
+                    ),
+                )
+                if data.read_bool()
+                else None
+            ),
             data={  # Choice
                 0: lambda: ("None", None),
                 1: lambda: (
@@ -2181,12 +2302,12 @@ class GameEventsReader_64469(GameEventsReader_38996):
                         timer=data.read_uint8(),
                         unit_tag=data.read_uint32(),
                         unit_link=data.read_uint16(),
-                        control_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
-                        upkeep_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
+                        control_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
+                        upkeep_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
                         point=dict(
                             x=data.read_bits(20),
                             y=data.read_bits(20),
@@ -2233,13 +2354,17 @@ class GameEventsReader_80669(GameEventsReader_65895):
     def command_event(self, data):
         return dict(
             flags=data.read_bits(27),
-            ability=dict(
-                ability_link=data.read_uint16(),
-                ability_command_index=data.read_bits(5),
-                ability_command_data=data.read_uint8() if data.read_bool() else None,
-            )
-            if data.read_bool()
-            else None,
+            ability=(
+                dict(
+                    ability_link=data.read_uint16(),
+                    ability_command_index=data.read_bits(5),
+                    ability_command_data=(
+                        data.read_uint8() if data.read_bool() else None
+                    ),
+                )
+                if data.read_bool()
+                else None
+            ),
             data={  # Choice
                 0: lambda: ("None", None),
                 1: lambda: (
@@ -2259,12 +2384,12 @@ class GameEventsReader_80669(GameEventsReader_65895):
                         timer=data.read_uint8(),
                         unit_tag=data.read_uint32(),
                         unit_link=data.read_uint16(),
-                        control_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
-                        upkeep_player_id=data.read_bits(4)
-                        if data.read_bool()
-                        else None,
+                        control_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
+                        upkeep_player_id=(
+                            data.read_bits(4) if data.read_bool() else None
+                        ),
                         point=dict(
                             x=data.read_bits(20),
                             y=data.read_bits(20),

--- a/test_replays/test_replays.py
+++ b/test_replays/test_replays.py
@@ -170,7 +170,9 @@ class TestReplays(unittest.TestCase):
         replay = sc2reader.load_replay("test_replays/1.1.3.16939/11.SC2Replay")
         self.assertEqual(replay.expansion, "WoL")
         first = [player for player in replay.players if player.name == "명지대학교"][0]
-        second = [player for player in replay.players if player.name == "티에스엘사기수"][0]
+        second = [
+            player for player in replay.players if player.name == "티에스엘사기수"
+        ][0]
         self.assertEqual(first.url, "https://starcraft2.com/en-us/profile/3/1/258945")
         self.assertEqual(second.url, "https://starcraft2.com/en-us/profile/3/1/102472")
         self.assertEqual(replay.messages[0].text, "sc2.replays.net")


### PR DESCRIPTION
Adds the DialogControlEvent game event type.

This is for interactions with dialogs ingame and allows for some neat data collection as it looks to generate an event when a trigger modifys a dialog field aswell.

Control ID seems for the most part useless
Event types seem to match with the ones listed here https://mapster.talv.space/galaxy/reference/preset-control-event-type
Event data contains what a dialog text box was changedto, if a check box checked or unchecked, etc