### PR TITLE
Upgrade CircleCI Python orb to version v4.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ orbs:
 
 jobs:
   pre-commit:
-    # executor:
-    #  name: python/default
+    executor:
+      name: python/default
     #  tag: "3.14"
     steps:
       - checkout
@@ -18,8 +18,8 @@ jobs:
             uvx pre-commit run --all-files --show-diff-on-failure
 
   pytest:
-    # executor:
-    #  name: python/default
+    executor:
+      name: python/default
     #  tag: "3.14"
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@
 
 version: '2.1'
 orbs:
-  python: circleci/python@3.3.0
+  python: circleci/python@4.0.0
 
 jobs:
   pre-commit:
-    executor:
-      name: python/default
-      tag: "3.14"
+    # executor:
+    #  name: python/default
+    #  tag: "3.14"
     steps:
       - checkout
       - python/install-packages:
@@ -18,9 +18,9 @@ jobs:
             uvx pre-commit run --all-files --show-diff-on-failure
 
   pytest:
-    executor:
-      name: python/default
-      tag: "3.14"
+    # executor:
+    #  name: python/default
+    #  tag: "3.14"
     steps:
       - checkout
       - python/install-packages:


### PR DESCRIPTION
Updated Python orb version and commented out executor configuration.
https://github.com/CircleCI-Public/python-orb/releases/tag/v4.0.0