### PR TITLE
Update new cdn host for the CN server

### DIFF
--- a/sc2reader/utils.py
+++ b/sc2reader/utils.py
@@ -1,7 +1,7 @@
 import binascii
 import json
 import os
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 
 from sc2reader.constants import COLOR_CODES, COLOR_CODES_INV
 from sc2reader.exceptions import MPQError
@@ -201,8 +201,7 @@ def get_resource_url(region, hash, type):
     if region == "sea":
         region = "us"
     elif region == "cn":
-        scheme = "http"
-        domain = "battlenet.com.cn"
+        domain = "necdn.leihuo.netease.com"
     return url_template.format(scheme, region, domain, hash, type)
 
 


### PR DESCRIPTION
Resolves #200.

This PR updates the CDN host for the CN server. The new host is:`necdn.leihuo.netease.com`.

The previous host that I updated in #154 is no longer valid.

Example:
https://cn-s2-depot.necdn.leihuo.netease.com/5699cfd7055c334f7bccce4798a378e25d3453c6294175aca309440f0a9fcb57.s2ma